### PR TITLE
Move VLAN and Bandwidth methods into VLAN and Bandwidth Service Classes

### DIFF
--- a/core/src/main/java/net/es/oscars/pce/BandwidthService.java
+++ b/core/src/main/java/net/es/oscars/pce/BandwidthService.java
@@ -1,0 +1,578 @@
+package net.es.oscars.pce;
+
+
+import lombok.extern.slf4j.Slf4j;
+import net.es.oscars.resv.dao.ReservedBandwidthRepository;
+import net.es.oscars.resv.ent.*;
+import net.es.oscars.topo.beans.TopoEdge;
+import net.es.oscars.topo.beans.TopoVertex;
+import net.es.oscars.topo.dao.UrnRepository;
+import net.es.oscars.topo.ent.ReservableBandwidthE;
+import net.es.oscars.topo.ent.UrnE;
+import net.es.oscars.topo.enums.VertexType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Component
+public class BandwidthService {
+
+    @Autowired
+    private ReservedBandwidthRepository resvBwRepo;
+
+    @Autowired
+    private UrnRepository urnRepository;
+
+    /**
+     * Build a map of the available bandwidth at each URN. For each URN, there is a map of "Ingress" and "Egress"
+     * bandwidth available. Only port URNs can be found in this map.
+     * @param rsvBandwidths - A list of all bandwidth reserved so far
+     * @return A mapping of URN to Ingress/Egress bandwidth availability
+     */
+    public Map<UrnE, Map<String, Integer>> createBandwidthAvailabilityMap(List<ReservedBandwidthE> rsvBandwidths){
+        // Build a map, allowing us to retrieve a list of ReservedBandwidth given the associated URN
+        Map<UrnE, List<ReservedBandwidthE>> resvBwMap = buildReservedBandwidthMap(rsvBandwidths);
+
+        // Build a map, allowing us to retrieve the available "Ingress" and "Egress" bandwidth at each associated URN
+        Map<UrnE, Map<String, Integer>> availBwMap = new HashMap<>();
+        urnRepository.findAll()
+                .stream()
+                .filter(urn -> urn.getReservableBandwidth() != null)
+                .forEach(urn -> availBwMap.put(urn, getBwAvailabilityForUrn(urn, urn.getReservableBandwidth(), resvBwMap)));
+
+        return availBwMap;
+    }
+
+    /**
+     * Given a set of reserved junctions and reserved MPLS / ETHERNET pipes, extract the reserved bandwidth objects
+     * which fall within the requested schedule period and return them all together as a list
+     * @param reservedJunctions - Set of reserved ethernet junctions
+     * @param reservedMplsPipes - Set of reserved MPLS pipes
+     * @param reservedEthPipes - Set of reserved Ethernet pipes
+     * @param sched - The requested schedule (start and end date)
+     * @return List of all reserved bandwidth contained within reserved pipes and the reserved repository.
+     */
+    public List<ReservedBandwidthE> createReservedBandwidthList(Set<ReservedVlanJunctionE> reservedJunctions,
+                                                                Set<ReservedMplsPipeE> reservedMplsPipes,
+                                                                Set<ReservedEthPipeE> reservedEthPipes,
+                                                                ScheduleSpecificationE sched){
+        // Retrieve all bandwidth reserved so far from pipes & junctions
+        List<ReservedBandwidthE> rsvBandwidths = retrieveReservedBandwidths(reservedJunctions);
+        rsvBandwidths.addAll(retrieveReservedBandwidthsFromMplsPipes(reservedMplsPipes));
+        rsvBandwidths.addAll(retrieveReservedBandwidthsFromEthPipes(reservedEthPipes));
+        rsvBandwidths.addAll(getReservedBandwidth(sched.getNotBefore(), sched.getNotAfter()));
+
+        return rsvBandwidths;
+    }
+
+
+    /**
+     * Build a map of the requested bandwidth at each port TopoVertex contained within the az and za EROs.
+     * @param azERO - The path in the AZ direction
+     * @param zaERO - The path in the ZA direction
+     * @param azMbps - The requested bandwidth in the AZ direction
+     * @param zaMbps - The requested bandwidth in the ZA direction
+     * @return A mapping from TopoVertex (ports only) to requested "Ingress" and "Egress" bandwidth
+     */
+    public Map<TopoVertex, Map<String, Integer>> createRequestedBandwidthMap(List<TopoEdge> azERO, List<TopoEdge> zaERO,
+                                                                             Integer azMbps, Integer zaMbps){
+        // Map a port node to a map of "Ingress" and "Egress" requested bandwidth values
+        Map<TopoVertex, Map<String, Integer>> requestedBandwidthMap = new HashMap<>();
+
+        // Iterate through the AZ edges, update the map for each port node found in the path
+        for(TopoEdge azEdge : azERO){
+            updateRequestedBandwidthMap(azEdge, azMbps, requestedBandwidthMap);
+        }
+
+        // Iterate through the ZA edges, update the map for each port node in the path
+        for(TopoEdge zaEdge : zaERO){
+            updateRequestedBandwidthMap(zaEdge, zaMbps, requestedBandwidthMap);
+        }
+
+        return requestedBandwidthMap;
+    }
+
+    /**
+     * Update the values in a mapping of port vertices to requested Ingress/Egress bandwidth.
+     * @param edge - An edge, with a vertex on the "A" side and on the "Z" side
+     * @param bandwidth - The requested bandwidth in one direction
+     * @param requestedBandwidthMap - The soon-to-be updated map of requested bandwidth per port
+     */
+    private void updateRequestedBandwidthMap(TopoEdge edge, Integer bandwidth,
+                                             Map<TopoVertex, Map<String, Integer>> requestedBandwidthMap){
+
+        // Retrieve the "A" side of the edge
+        TopoVertex nodeA = edge.getA();
+        // Retrieve the "Z" side of the edge
+        TopoVertex nodeZ = edge.getZ();
+
+        // Add node A to the map if it is a port and it is not already in the map
+        if(nodeA.getVertexType().equals(VertexType.PORT) && !requestedBandwidthMap.containsKey(nodeA)){
+            requestedBandwidthMap.put(nodeA, makeInitialBandwidthMap());
+        }
+        // Add node Z to the map if it is a port and it is not already in the map
+        if(nodeZ.getVertexType().equals(VertexType.PORT) && !requestedBandwidthMap.containsKey(nodeZ)){
+            requestedBandwidthMap.put(nodeZ, makeInitialBandwidthMap());
+        }
+
+        // All Cases: Add the requested bandwidth to the amount already stored in the map
+        // Case 1: portA -> portZ -- portA = egress, portZ = ingress
+        /*
+        if(nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
+        {
+            Integer updatedEgress = requestedBandwidthMap.get(nodeA).get("Egress") + bandwidth;
+            requestedBandwidthMap.get(nodeA).put("Egress", updatedEgress);
+
+            Integer updatedIngress = requestedBandwidthMap.get(nodeZ).get("Ingress") + bandwidth;
+            requestedBandwidthMap.get(nodeZ).put("Ingress", updatedIngress);
+        }*/
+        // Case 2: portA -> deviceZ -- portA = ingress
+        if(nodeA.getVertexType().equals(VertexType.PORT) && !nodeZ.getVertexType().equals(VertexType.PORT))
+        {
+            Integer updatedIngress = requestedBandwidthMap.get(nodeA).get("Ingress") + bandwidth;
+            requestedBandwidthMap.get(nodeA).put("Ingress", updatedIngress);
+        }
+        // Case 3: deviceA -> portZ -- portZ = egress
+        else if(!nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
+        {
+            Integer updatedEgress = requestedBandwidthMap.get(nodeZ).get("Egress") + bandwidth;
+            requestedBandwidthMap.get(nodeZ).put("Egress", updatedEgress);
+        }
+
+    }
+
+    /**
+     * Build an initial map of requested bandwidth in the Ingress and Egress directions
+     * @return A new map with 0 Ingress and Egress bandwidth.
+     */
+    private Map<String, Integer> makeInitialBandwidthMap(){
+        Map<String, Integer> initialMap = new HashMap<>();
+        initialMap.put("Ingress", 0);
+        initialMap.put("Egress", 0);
+        return initialMap;
+    }
+
+
+    /**
+     * Examine all AZ and ZA edges, confirm that the requested bandwidth can be supported given the available bandwidth.
+     * @param urnMap - A map of URN string to URN objects
+     * @param azERO - The path in the A->Z direction
+     * @param zaERO - The path in the Z->A direction
+     * @param availBwMap - A map of bandwidth availability
+     * @return True, if there is sufficient bandwidth across all edges. False, otherwise.
+     */
+    public boolean checkForSufficientBw(Map<String, UrnE> urnMap, Integer azMbps, Integer zaMbps, List<TopoEdge> azERO,
+                                        List<TopoEdge> zaERO, Map<UrnE, Map<String, Integer>> availBwMap) {
+
+        // For the AZ direction, fail the test if there is insufficient bandwidth
+        if(!sufficientBandwidthForERO(azERO, urnMap, availBwMap, azMbps, zaMbps)){
+            return false;
+        }
+
+        // For each ZA direction, fail the test if there is insufficient bandwidth
+        return sufficientBandwidthForERO(zaERO, urnMap, availBwMap, azMbps, zaMbps);
+    }
+
+    /**
+     * Examine all edges, confirm that the requested bandwidth can be supported given the available bandwidth.
+     * @param urnMap - A map of URN string to URN objects
+     * @param bwMbps - The requested bandwidth (in one direction)
+     * @param availBwMap - A map of bandwidth availability
+     * @return True, if there is sufficient bandwidth across all edges. False, otherwise.
+     */
+    public boolean checkForSufficientBwUni(Map<String, UrnE> urnMap, Integer bwMbps, List<TopoEdge> ERO,
+                                           Map<UrnE, Map<String, Integer>> availBwMap){
+        // For the AZ direction, fail the test if there is insufficient bandwidth
+        return sufficientBandwidthForEROUni(ERO, urnMap, availBwMap, bwMbps);
+    }
+
+    /**
+     * Given a particular list of edges, iterate and confirm that there is sufficient bandwidth available in both directions
+     * @param ERO - A series of edges
+     * @param urnMap - A mapping of URN strings to URN objects
+     * @param availBwMap - A mapping of URN objects to lists of available bandwidth for that URN
+     * @param azMbps - The bandwidth in the AZ direction
+     * @param zaMbps - The bandwidth the ZA direction
+     * @return True, if the segment can support the requested bandwidth. False, otherwise.
+     */
+    private boolean sufficientBandwidthForERO(List<TopoEdge> ERO, Map<String, UrnE> urnMap,
+                                              Map<UrnE, Map<String, Integer>> availBwMap, Integer azMbps,
+                                              Integer zaMbps){
+        // For each edge in that list
+        for(TopoEdge edge : ERO){
+            // Retrieve the URNs
+            String urnStringA = edge.getA().getUrn();
+            String urnStringZ = edge.getZ().getUrn();
+            if(!urnMap.containsKey(urnStringA) || !urnMap.containsKey(urnStringZ)){
+                return false;
+            }
+            UrnE urnA = urnMap.get(urnStringA);
+            UrnE urnZ = urnMap.get(urnStringZ);
+
+            // If URN A has reservable bandwidth, confirm that there is enough available
+            if(urnA.getReservableBandwidth() != null){
+                if(!sufficientBandwidthAtUrn(urnA, availBwMap, azMbps, zaMbps)){
+                    return false;
+                }
+            }
+
+            // If URN Z has reservable bandwidth, confirm that there is enough available
+            if(urnZ.getReservableBandwidth() != null){
+                if(!sufficientBandwidthAtUrn(urnZ, availBwMap, azMbps, zaMbps)){
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Given a list of edges, confirm that there is sufficient bandwidth available in the one direction
+     * @param ERO - A series of edges
+     * @param urnMap - A mapping of URN strings to URN objects
+     * @param availBwMap - A mapping of URN objects to lists of reserved bandwidth for that URN
+     * @param bwMbps - The bandwidth in the specified direction
+     * @return True, if the segment can support the requested bandwidth. False, otherwise.
+     */
+    private boolean sufficientBandwidthForEROUni(List<TopoEdge> ERO, Map<String, UrnE> urnMap,
+                                                 Map<UrnE, Map<String, Integer>> availBwMap, Integer bwMbps)
+    {
+        // For each edge in that list
+        for(TopoEdge edge : ERO)
+        {
+            Map<UrnE, Boolean> urnIngressDirectionMap = new HashMap<>();
+            TopoVertex nodeA = edge.getA();
+            TopoVertex nodeZ = edge.getZ();
+            String urnStringA = nodeA.getUrn();
+            String urnStringZ = nodeZ.getUrn();
+
+            if(!urnMap.containsKey(urnStringA) || !urnMap.containsKey(urnStringZ))
+            {
+                return false;
+            }
+
+            UrnE urnA = urnMap.get(urnStringA);
+            UrnE urnZ = urnMap.get(urnStringZ);
+
+            // From Port to Device -- Consider Ingress direction for this Port
+            if(nodeA.getVertexType().equals(VertexType.PORT) && !nodeZ.getVertexType().equals(VertexType.PORT))
+            {
+                urnIngressDirectionMap.put(urnA, true);
+            }
+            // From Device to Port -- Consider Egress direction for this Port
+            else if(!nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
+            {
+                urnIngressDirectionMap.put(urnZ, false);
+            }
+            // From Port to Port -- Consider Egress for portA, and Ingress for portZ
+            else if(nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
+            {
+                urnIngressDirectionMap.put(urnA, false);
+                urnIngressDirectionMap.put(urnZ, true);
+            }
+
+            // If URN A has reservable bandwidth, confirm that there is enough available
+            if(urnA.getReservableBandwidth() != null)
+            {
+                boolean ingressDirection = urnIngressDirectionMap.get(urnA);
+
+                if(!sufficientBandwidthAtUrnUni(urnA, availBwMap, bwMbps, ingressDirection))
+                {
+                    return false;
+                }
+            }
+
+            // If URN Z has reservable bandwidth, confirm that there is enough available
+            if(urnZ.getReservableBandwidth() != null)
+            {
+                boolean ingressDirection = urnIngressDirectionMap.get(urnZ);
+
+                if(!sufficientBandwidthAtUrnUni(urnZ, availBwMap, bwMbps, ingressDirection))
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Given a specific URN, determine if there is enough bandwidth available to support the requested bandwidth
+     * @param urn - The URN
+     * @param availBwMap - Map of URNs to available Bandwidth
+     * @param inMbps - Requested ingress Mbps
+     * @param egMbps - Requested egress Mbps
+     * @return True, if there is enough available bandwidth at the URN. False, otherwise
+     */
+    public boolean sufficientBandwidthAtUrn(UrnE urn, Map<UrnE, Map<String, Integer>> availBwMap,
+                                            Integer inMbps, Integer egMbps){
+        Map<String, Integer> bwAvail = availBwMap.get(urn);
+        if(bwAvail.get("Ingress") < inMbps || bwAvail.get("Egress") < egMbps){
+            log.error("Insufficient Bandwidth at " + urn.toString() + ". Requested: " +
+                    inMbps + " In and " + egMbps + " Out. Available: " + bwAvail.get("Ingress") +
+                    " In and " + bwAvail.get("Egress") + " Out.");
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Given a specific URN, determine if there is enough bandwidth available to support the requested bandwidth in a specific (ingress/egress) direction
+     * @param urn - The URN
+     * @param availBwMap - Map of URNs to Available Bandwidth
+     * @param bwMbps - Requested Mbps
+     * @param ingressDirection - True if pruning is done based upon port ingress b/w, false if done by egress b/w
+     * @return True, if there is enough available bandwidth at the URN. False, otherwise
+     */
+    private boolean sufficientBandwidthAtUrnUni(UrnE urn, Map<UrnE, Map<String, Integer>> availBwMap,
+                                                Integer bwMbps, boolean ingressDirection){
+        Map<String, Integer> bwAvail = availBwMap.get(urn);
+
+        Integer unidirectionalBW;
+        String direction = "";
+
+        if(ingressDirection)
+        {
+            unidirectionalBW = bwAvail.get("Ingress");
+            direction = " In.";
+        }
+        else
+        {
+            unidirectionalBW = bwAvail.get("Egress");
+            direction = " Out.";
+        }
+
+        if(unidirectionalBW < bwMbps)
+        {
+            log.error("Insufficient Bandwidth at " + urn.toString() + ". Requested: " + bwMbps + direction);
+            return false;
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Confirm that a requested VLAN junction supports the requested bandwidth. Checks each fixture of the junction.
+     * @param req_j - The requested junction.
+     * @param reservedBandwidths - The reserved bandwidth.
+     * @return True, if there is enough bandwidth at every fixture. False, otherwise.
+     */
+    public boolean confirmSufficientBandwidth(RequestedVlanJunctionE req_j, List<ReservedBandwidthE> reservedBandwidths){
+
+        // All requested fixtures on this junction
+        Set<RequestedVlanFixtureE> reqFixtures = req_j.getFixtures();
+
+
+        // Get map of "Ingress" and "Egress" bandwidth availability
+        Map<UrnE, Map<String, Integer>> availBwMap = createBandwidthAvailabilityMap(reservedBandwidths);
+
+        // For each requested fixture,
+        for(RequestedVlanFixtureE reqFix: reqFixtures){
+            // Confirum that there is enough available bandwidth at that URN
+            if(!sufficientBandwidthAtUrn(reqFix.getPortUrn(), availBwMap, reqFix.getInMbps(), reqFix.getEgMbps())){
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Retrieve all reserved bandwidths from a set of reserved junctions.
+     * @param junctions - Set of reserved junctions.
+     * @return A list of all bandwidth reserved at those junctions.
+     */
+    public List<ReservedBandwidthE> retrieveReservedBandwidths(Set<ReservedVlanJunctionE> junctions){
+        return junctions
+                .stream()
+                .map(ReservedVlanJunctionE::getFixtures)
+                .flatMap(Collection::stream)
+                .map(ReservedVlanFixtureE::getReservedBandwidth)
+                .collect(Collectors.toList());
+    }
+
+
+    /**
+     * Retrieve all Reserved Bandwidth from a set of reserved MPLS pipes.
+     * @param reservedPipes - Set of reserved pipes
+     * @return A list of all reserved bandwidth within the set of reserved MPLS pipes.
+     */
+    public List<ReservedBandwidthE> retrieveReservedBandwidthsFromMplsPipes(Set<ReservedMplsPipeE> reservedPipes) {
+        return reservedPipes
+                .stream()
+                .map(ReservedMplsPipeE::getReservedBandwidths)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieve all Reserved Bandwidth from a set of reserved Ethernet pipes.
+     * @param reservedPipes - Set of reserved pipes
+     * @return A list of all reserved bandwidth within the set of reserved Ethernet pipes.
+     */
+    public List<ReservedBandwidthE> retrieveReservedBandwidthsFromEthPipes(Set<ReservedEthPipeE> reservedPipes) {
+        return reservedPipes
+                .stream()
+                .map(ReservedEthPipeE::getReservedBandwidths)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+
+
+    ///// FROM PRUNING SERVICE
+
+    /**
+     * Get a list of all bandwidth reserved between a start and end date/time.
+     * @param start - The start of the time range
+     * @param end - The end of the time range
+     * @return A list of reserved bandwidth
+     */
+    public List<ReservedBandwidthE> getReservedBandwidth(Date start, Date end){
+        // Get all Reserved Bandwidth between start and end
+        Optional<List<ReservedBandwidthE>> optResvBw = resvBwRepo.findOverlappingInterval(start.toInstant(), end.toInstant());
+        return optResvBw.isPresent() ? optResvBw.get() : new ArrayList<>();
+    }
+
+
+    /**
+     * Build a mapping of UrnE objects to ReservedBandwidthE objects.
+     * @param rsvBwList A list of all bandwidth reserved.
+     * @return A map of UrnE to ReservedBandwidthE objects
+     */
+    public Map<UrnE, List<ReservedBandwidthE>> buildReservedBandwidthMap(List<ReservedBandwidthE> rsvBwList) {
+        Map<UrnE, List<ReservedBandwidthE>> map = new HashMap<>();
+        for(ReservedBandwidthE resv : rsvBwList){
+            UrnE resvUrn = resv.getUrn();
+            if(!map.containsKey(resvUrn)){
+                map.put(resvUrn, new ArrayList<>());
+            }
+            map.get(resvUrn).add(resv);
+        }
+        return map;
+    }
+
+
+
+    /**
+     * Evaluate an edge to determine if the nodes on either end of the edge support the requested
+     * az and za bandwidths. An edge will only fail the test if one or both URNs (corresponding to the nodes):
+     * (1) have valid reservable bandwidth fields, and (2) the URN(s) do not have sufficient available bandwidth
+     * available in both the az and za directions (egress and ingress).
+     * @param edge - The edge to be evaluated.
+     * @param azBw - The requested bandwidth in one direction.
+     * @param zaBw - The requested bandwidth in the other direction.
+     * @param urnMap - Map of URN name to UrnE object.
+     * @param resvBwMap - Map of UrnE objects to Lists of Reserved Bandwidth
+     * @return True if there is sufficient reservable bandwidth, False otherwise.
+     */
+    public boolean bwAvailable(TopoEdge edge, Integer azBw, Integer zaBw, Map<String, UrnE> urnMap, Map<UrnE, List<ReservedBandwidthE>> resvBwMap){
+
+        // Get the reservable bandwidth for the URN matching the node on the "a" side of the edge.
+        ReservableBandwidthE aBandwidth = urnMap.get(edge.getA().getUrn()) != null ?
+                urnMap.get(edge.getA().getUrn()).getReservableBandwidth() : null;
+        // Get the reservable bandwidth for the URN matching the node on the "z" side of the edge.
+        ReservableBandwidthE zBandwidth = urnMap.get(edge.getZ().getUrn()) != null ?
+                urnMap.get(edge.getZ().getUrn()).getReservableBandwidth() : null;
+
+
+        // At least one of the two has reservable bandwidth, so check the valid nodes to determine
+        // If they have sufficient bandwidth. In the case of a (device, port) edge, only the port must be checked.
+        // If it is a (port, port) edge, then both must be checked.
+        boolean aPasses = true;
+        boolean zPasses = true;
+        if(aBandwidth != null){
+            // Get a map of the available Ingress/Egress bandwidth for URN a
+            Map<String, Integer> aAvailBwMap = getBwAvailabilityForUrn(urnMap.get(edge.getA().getUrn()), aBandwidth, resvBwMap);
+            aPasses = aAvailBwMap.get("Egress") >= azBw && aAvailBwMap.get("Ingress") >= zaBw;
+        }
+        if(zBandwidth != null){
+            // Get a map of the available Ingress/Egress bandwidth for URN z
+            Map<String, Integer> zAvailBwMap = getBwAvailabilityForUrn(urnMap.get(edge.getZ().getUrn()), zBandwidth, resvBwMap);
+            zPasses = zAvailBwMap.get("Ingress") >= azBw && zAvailBwMap.get("Egress") >= zaBw;
+        }
+
+        return aPasses && zPasses;
+
+
+    }
+
+    /**
+     * Evaluate an edge to determine if the nodes on either end of the edge support the requested
+     * unidriectional bandwidth. An edge will only fail the test if one or both URNs (corresponding to the nodes):
+     * (1) have valid reservable bandwidth fields, and (2) the URN(s) do not have sufficient available bandwidth
+     * available in the unique direction.
+     * @param edge - The edge to be evaluated.
+     * @param theBw - The requested bandwidth in one direction.
+     * @param urnMap - Map of URN name to UrnE object.
+     * @param resvBwMap - Map of UrnE objects to Lists of Reserved Bandwidth
+     * @return True if there is sufficient reservable bandwidth, False otherwise.
+     */
+    public boolean bwAvailableUni(TopoEdge edge, Integer theBw, Map<String, UrnE> urnMap, Map<UrnE, List<ReservedBandwidthE>> resvBwMap){
+
+        if(!edge.getA().getVertexType().equals(VertexType.PORT) || !edge.getZ().getVertexType().equals(VertexType.PORT))
+            return true;
+
+        // Get the reservable bandwidth for the URN matching the node on the "a" side of the edge.
+        ReservableBandwidthE aBandwidth = urnMap.get(edge.getA().getUrn()) != null ?
+                urnMap.get(edge.getA().getUrn()).getReservableBandwidth() : null;
+        // Get the reservable bandwidth for the URN matching the node on the "z" side of the edge.
+        ReservableBandwidthE zBandwidth = urnMap.get(edge.getZ().getUrn()) != null ?
+                urnMap.get(edge.getZ().getUrn()).getReservableBandwidth() : null;
+
+        // At least one of the two has reservable bandwidth, so check the valid nodes to determine
+        // If they have sufficient bandwidth In the case of a (device, port) edge, only the port must be checked.
+        // If it is a (port, port) edge, then both must be checked.
+        boolean aPasses = true;
+        boolean zPasses = true;
+
+        if(aBandwidth != null)
+        {
+            // Get a map of the available Ingress/Egress bandwidth for URN a
+            Map<String, Integer> aAvailBwMap = getBwAvailabilityForUrn(urnMap.get(edge.getA().getUrn()), aBandwidth, resvBwMap);
+            aPasses = aAvailBwMap.get("Egress") >= theBw;
+        }
+        if(zBandwidth != null)
+        {
+            // Get a map of the available Ingress/Egress bandwidth for URN z
+            Map<String, Integer> zAvailBwMap = getBwAvailabilityForUrn(urnMap.get(edge.getZ().getUrn()), zBandwidth, resvBwMap);
+            zPasses = zAvailBwMap.get("Ingress") >= theBw;
+        }
+
+        return aPasses && zPasses;
+    }
+    /**
+     * Determine how much Ingress/Egress bandwidth is still available at a URN. If the list of reserved bandwidths
+     * is empty, then all of the Reservable Bandwidth at that URN is available. Otherwise,
+     * subtract the sum Ingress/Egress bandwidth from the maximum reservable bandwidth at that URN.
+     * @param bandwidth - ReservableBandwidthE object, which contains the maximum Ingress/Egress bandwidth for a given URN
+     * @param resvBwMap - A Mapping from a URN to a list of Reserved Bandwidths at that URN.
+     * @return A map containing the net available ingress/egress bandwidth at a URN
+     */
+    public Map<String,Integer> getBwAvailabilityForUrn(UrnE urn, ReservableBandwidthE bandwidth, Map<UrnE, List<ReservedBandwidthE>> resvBwMap) {
+        Map<String, Integer> availBw = new HashMap<>();
+        availBw.put("Ingress", bandwidth.getIngressBw());
+        availBw.put("Egress", bandwidth.getEgressBw());
+        if(resvBwMap.containsKey(urn)){
+            List<ReservedBandwidthE> resvBwList = resvBwMap.get(urn);
+            Integer sumIngress = 0;
+            Integer sumEgress = 0;
+            for(ReservedBandwidthE resv : resvBwList){
+                sumIngress += resv.getInBandwidth();
+                sumEgress += resv.getEgBandwidth();
+            }
+            availBw.put("Ingress", Math.max(bandwidth.getIngressBw() - sumIngress, 0));
+            availBw.put("Egress", Math.max(bandwidth.getEgressBw() - sumEgress, 0));
+        }
+        return availBw;
+    }
+
+}

--- a/core/src/main/java/net/es/oscars/pce/PruningService.java
+++ b/core/src/main/java/net/es/oscars/pce/PruningService.java
@@ -38,10 +38,10 @@ public class PruningService {
     private UrnRepository urnRepo;
 
     @Autowired
-    private ReservedBandwidthRepository resvBwRepo;
+    private VlanService vlanSvc;
 
     @Autowired
-    private ReservedVlanRepository resvVlanRepo;
+    private BandwidthService bwSvc;
 
 
     /**
@@ -55,7 +55,7 @@ public class PruningService {
      */
     public Topology pruneWithBwVlans(Topology topo, Integer Bw, String vlans, List<UrnE> urns,
                                      List<ReservedBandwidthE> rsvBwList, List<ReservedVlanE> rsvVlanList){
-        return pruneTopology(topo, Bw, Bw, getIntRangesFromString(vlans), urns, rsvBwList, rsvVlanList);
+        return pruneTopology(topo, Bw, Bw, vlanSvc.getIntRangesFromString(vlans), urns, rsvBwList, rsvVlanList);
     }
 
     /**
@@ -67,8 +67,8 @@ public class PruningService {
      * @return The topology with ineligible edges removed.
      */
     public Topology pruneWithBwVlans(Topology topo, Integer Bw, String vlans, Date start, Date end){
-        return pruneTopology(topo, Bw, Bw, getIntRangesFromString(vlans), urnRepo.findAll(),
-                getReservedBandwidth(start, end), getReservedVlans(start, end));
+        return pruneTopology(topo, Bw, Bw, vlanSvc.getIntRangesFromString(vlans), urnRepo.findAll(),
+                bwSvc.getReservedBandwidth(start, end), vlanSvc.getReservedVlans(start, end));
     }
 
     /**
@@ -82,7 +82,7 @@ public class PruningService {
      */
     public Topology pruneWithAZBwVlans(Topology topo, Integer azBw, Integer zaBw, String vlans, List<UrnE> urns,
                                        List<ReservedBandwidthE> rsvBwList, List<ReservedVlanE> rsvVlanList){
-        return pruneTopology(topo, azBw, zaBw, getIntRangesFromString(vlans), urns, rsvBwList, rsvVlanList);
+        return pruneTopology(topo, azBw, zaBw, vlanSvc.getIntRangesFromString(vlans), urns, rsvBwList, rsvVlanList);
     }
 
     /**
@@ -95,8 +95,8 @@ public class PruningService {
      * @return The topology with ineligible edges removed.
      */
     public Topology pruneWithAZBwVlans(Topology topo, Integer azBw, Integer zaBw, String vlans, Date start, Date end){
-        return pruneTopology(topo, azBw, zaBw, getIntRangesFromString(vlans), urnRepo.findAll(),
-                getReservedBandwidth(start, end), getReservedVlans(start, end));
+        return pruneTopology(topo, azBw, zaBw, vlanSvc.getIntRangesFromString(vlans), urnRepo.findAll(),
+                bwSvc.getReservedBandwidth(start, end), vlanSvc.getReservedVlans(start, end));
     }
 
     /**
@@ -122,7 +122,7 @@ public class PruningService {
      */
     public Topology pruneWithBw(Topology topo, Integer Bw, Date start, Date end){
         return pruneTopology(topo, Bw, Bw, new ArrayList<>(), urnRepo.findAll(),
-                getReservedBandwidth(start, end), getReservedVlans(start, end));
+                bwSvc.getReservedBandwidth(start, end), vlanSvc.getReservedVlans(start, end));
     }
 
     /**
@@ -151,7 +151,7 @@ public class PruningService {
      */
     public Topology pruneWithAZBw(Topology topo, Integer azBw, Integer zaBw, Date start, Date end){
         return pruneTopology(topo, azBw, zaBw, new ArrayList<>(), urnRepo.findAll(),
-                getReservedBandwidth(start, end), getReservedVlans(start, end));
+                bwSvc.getReservedBandwidth(start, end), vlanSvc.getReservedVlans(start, end));
     }
 
 
@@ -166,7 +166,7 @@ public class PruningService {
         Date start = sched.getNotBefore();
         Date end = sched.getNotAfter();
         return pruneWithPipe(topo, pipe, urnRepo.findAll(),
-                getReservedBandwidth(start, end), getReservedVlans(start, end));
+                bwSvc.getReservedBandwidth(start, end), vlanSvc.getReservedVlans(start, end));
     }
 
     /**
@@ -240,8 +240,8 @@ public class PruningService {
         Integer azBw = pipe.getAzMbps();
         Integer zaBw = pipe.getZaMbps();
         List<IntRange> vlans = new ArrayList<>();
-        vlans.addAll(getVlansFromJunction(pipe.getAJunction()));
-        vlans.addAll(getVlansFromJunction(pipe.getZJunction()));
+        vlans.addAll(vlanSvc.getVlansFromJunction(pipe.getAJunction()));
+        vlans.addAll(vlanSvc.getVlansFromJunction(pipe.getZJunction()));
         return pruneTopology(topo, azBw, zaBw, vlans, urns, rsvBwList, rsvVlanList);
     }
 
@@ -258,8 +258,8 @@ public class PruningService {
                                   List<ReservedBandwidthE> rsvBwList, List<ReservedVlanE> rsvVlanList){
         Integer azBw = pipe.getAzMbps();
         List<IntRange> vlans = new ArrayList<>();
-        vlans.addAll(getVlansFromJunction(pipe.getAJunction()));
-        vlans.addAll(getVlansFromJunction(pipe.getZJunction()));
+        vlans.addAll(vlanSvc.getVlansFromJunction(pipe.getAJunction()));
+        vlans.addAll(vlanSvc.getVlansFromJunction(pipe.getZJunction()));
         return pruneTopologyUni(topo, azBw, vlans, urns, rsvBwList, rsvVlanList);
     }
 
@@ -276,8 +276,8 @@ public class PruningService {
                                      List<ReservedBandwidthE> rsvBwList, List<ReservedVlanE> rsvVlanList){
         Integer zaBw = pipe.getZaMbps();
         List<IntRange> vlans = new ArrayList<>();
-        vlans.addAll(getVlansFromJunction(pipe.getAJunction()));
-        vlans.addAll(getVlansFromJunction(pipe.getZJunction()));
+        vlans.addAll(vlanSvc.getVlansFromJunction(pipe.getAJunction()));
+        vlans.addAll(vlanSvc.getVlansFromJunction(pipe.getZJunction()));
         return pruneTopologyUni(topo, zaBw, vlans, urns, rsvBwList, rsvVlanList);
     }
 
@@ -295,14 +295,14 @@ public class PruningService {
         Integer azBw = pipe.getAzMbps();
         Integer zaBw = pipe.getZaMbps();
         List<IntRange> vlans = new ArrayList<>();
-        vlans.addAll(getVlansFromJunction(pipe.getAJunction()));
-        vlans.addAll(getVlansFromJunction(pipe.getZJunction()));
+        vlans.addAll(vlanSvc.getVlansFromJunction(pipe.getAJunction()));
+        vlans.addAll(vlanSvc.getVlansFromJunction(pipe.getZJunction()));
 
         Date start = sched.getNotBefore();
         Date end = sched.getNotAfter();
 
         return pruneTopology(topo, azBw, zaBw, vlans, urns,
-                getReservedBandwidth(start, end), getReservedVlans(start, end));
+                bwSvc.getReservedBandwidth(start, end), vlanSvc.getReservedVlans(start, end));
     }
 
     /**
@@ -376,10 +376,10 @@ public class PruningService {
         Map<String, UrnE> urnMap = buildUrnMap(urns);
 
         // Build map of URN to resvBw
-        Map<UrnE, List<ReservedBandwidthE>> resvBwMap = buildReservedBandwidthMap(rsvBwList);
+        Map<UrnE, List<ReservedBandwidthE>> resvBwMap = bwSvc.buildReservedBandwidthMap(rsvBwList);
 
         // Build map of URN to resvVlan
-        Map<UrnE, List<ReservedVlanE>> resvVlanMap = buildReservedVlanMap(rsvVlanList);
+        Map<UrnE, List<ReservedVlanE>> resvVlanMap = vlanSvc.buildReservedVlanMap(rsvVlanList);
 
         // Copy the original topology's layer and set of vertices.
         Topology pruned = new Topology();
@@ -388,14 +388,14 @@ public class PruningService {
         // Filter out edges from the topology that do not have sufficient bandwidth available on both terminating nodes.
         // Also filters out all edges where either terminating node is not present in the URN map.
         Set<TopoEdge> availableEdges = topo.getEdges().stream()
-                .filter(e -> bwAvailable(e, azBw, zaBw, urnMap, resvBwMap))
+                .filter(e -> bwSvc.bwAvailable(e, azBw, zaBw, urnMap, resvBwMap))
                 .collect(Collectors.toSet());
         // If this is an MPLS topology, or there are no edges left, just take the bandwidth-pruned set of edges.
         // Otherwise, find all the remaining edges that can support the requested VLAN(s).
         if(pruned.getLayer() == Layer.MPLS || pruned.getLayer() == null || availableEdges.isEmpty()){
             pruned.setEdges(availableEdges);
         }else {
-            pruned.setEdges(findEdgesWithAvailableVlans(availableEdges, urnMap, vlans, resvVlanMap));
+            pruned.setEdges(vlanSvc.findEdgesWithAvailableVlans(availableEdges, urnMap, vlans, resvVlanMap));
         }
         return pruned;
     }
@@ -415,10 +415,10 @@ public class PruningService {
         Map<String, UrnE> urnMap = buildUrnMap(urns);
 
         // Build map of URN to resvBw
-        Map<UrnE, List<ReservedBandwidthE>> resvBwMap = buildReservedBandwidthMap(rsvBwList);
+        Map<UrnE, List<ReservedBandwidthE>> resvBwMap = bwSvc.buildReservedBandwidthMap(rsvBwList);
 
         // Build map of URN to resvVlan
-        Map<UrnE, List<ReservedVlanE>> resvVlanMap = buildReservedVlanMap(rsvVlanList);
+        Map<UrnE, List<ReservedVlanE>> resvVlanMap = vlanSvc.buildReservedVlanMap(rsvVlanList);
 
         // Copy the original topology's layer and set of vertices.
         Topology pruned = new Topology();
@@ -427,14 +427,14 @@ public class PruningService {
         // Filter out edges from the topology that do not have sufficient bandwidth available on both terminating nodes.
         // Also filters out all edges where either terminating node is not present in the URN map.
         Set<TopoEdge> availableEdges = topo.getEdges().stream()
-                .filter(e -> bwAvailableUni(e, theBw, urnMap, resvBwMap))
+                .filter(e -> bwSvc.bwAvailableUni(e, theBw, urnMap, resvBwMap))
                 .collect(Collectors.toSet());
         // If this is an MPLS topology, or there are no edges left, just take the bandwidth-pruned set of edges.
         // Otherwise, find all the remaining edges that can support the requested VLAN(s).
         if(pruned.getLayer() == Layer.MPLS || pruned.getLayer() == null || availableEdges.isEmpty()){
             pruned.setEdges(availableEdges);
         }else {
-            pruned.setEdges(findEdgesWithAvailableVlans(availableEdges, urnMap, vlans, resvVlanMap));
+            pruned.setEdges(vlanSvc.findEdgesWithAvailableVlans(availableEdges, urnMap, vlans, resvVlanMap));
         }
         return pruned;
     }
@@ -446,396 +446,6 @@ public class PruningService {
      */
     private Map<String,UrnE> buildUrnMap(List<UrnE> urns) {
         return urns.stream().collect(Collectors.toMap(UrnE::getUrn, urn -> urn));
-    }
-
-    /**
-     * Get a list of all bandwidth reserved between a start and end date/time.
-     * @param start - The start of the time range
-     * @param end - The end of the time range
-     * @return A list of reserved bandwidth
-     */
-    public List<ReservedBandwidthE> getReservedBandwidth(Date start, Date end){
-        // Get all Reserved Bandwidth between start and end
-        Optional<List<ReservedBandwidthE>> optResvBw = resvBwRepo.findOverlappingInterval(start.toInstant(), end.toInstant());
-        return optResvBw.isPresent() ? optResvBw.get() : new ArrayList<>();
-    }
-
-    /**
-     * Get a list of all VLAN IDs reserved between a start and end date/time.
-     * @param start - The start of the time range
-     * @param end - The end of the time range
-     * @return A list of reserved VLAN IDs
-     */
-    public List<ReservedVlanE> getReservedVlans(Date start, Date end){
-        //Get all Reserved VLan between start and end
-        Optional<List<ReservedVlanE>> optResvVlan = resvVlanRepo.findOverlappingInterval(start.toInstant(), end.toInstant());
-        return optResvVlan.isPresent() ? optResvVlan.get() : new ArrayList<>();
-    }
-
-    /**
-     * Build a mapping of UrnE objects to ReservedBandwidthE objects.
-     * @param rsvBwList A list of all bandwidth reserved.
-     * @return A map of UrnE to ReservedBandwidthE objects
-     */
-    public Map<UrnE, List<ReservedBandwidthE>> buildReservedBandwidthMap(List<ReservedBandwidthE> rsvBwList) {
-        Map<UrnE, List<ReservedBandwidthE>> map = new HashMap<>();
-        for(ReservedBandwidthE resv : rsvBwList){
-            UrnE resvUrn = resv.getUrn();
-            if(!map.containsKey(resvUrn)){
-                map.put(resvUrn, new ArrayList<>());
-            }
-            map.get(resvUrn).add(resv);
-        }
-        return map;
-    }
-
-    /**
-     * Build a mapping of UrnE objects to ReservedVlanE objects.
-     * @param rsvVlanList - A list of all reserved VLAN IDs
-     * @return A map of UrnE to ReservedVlanE objects
-     */
-    public Map<UrnE, List<ReservedVlanE>> buildReservedVlanMap(List<ReservedVlanE> rsvVlanList) {
-
-        Map<UrnE, List<ReservedVlanE>> map = new HashMap<>();
-        for(ReservedVlanE resv : rsvVlanList){
-            UrnE resvUrn = resv.getUrn();
-            if(!map.containsKey(resvUrn)){
-                map.put(resvUrn, new ArrayList<>());
-            }
-            map.get(resvUrn).add(resv);
-        }
-        return map;
-    }
-
-
-    /**
-     * Evaluate an edge to determine if the nodes on either end of the edge support the requested
-     * az and za bandwidths. An edge will only fail the test if one or both URNs (corresponding to the nodes):
-     * (1) have valid reservable bandwidth fields, and (2) the URN(s) do not have sufficient available bandwidth
-     * available in both the az and za directions (egress and ingress).
-     * @param edge - The edge to be evaluated.
-     * @param azBw - The requested bandwidth in one direction.
-     * @param zaBw - The requested bandwidth in the other direction.
-     * @param urnMap - Map of URN name to UrnE object.
-     * @param resvBwMap - Map of UrnE objects to Lists of Reserved Bandwidth
-     * @return True if there is sufficient reservable bandwidth, False otherwise.
-     */
-    private boolean bwAvailable(TopoEdge edge, Integer azBw, Integer zaBw, Map<String, UrnE> urnMap, Map<UrnE, List<ReservedBandwidthE>> resvBwMap){
-
-        // Get the reservable bandwidth for the URN matching the node on the "a" side of the edge.
-        ReservableBandwidthE aBandwidth = urnMap.get(edge.getA().getUrn()) != null ?
-                urnMap.get(edge.getA().getUrn()).getReservableBandwidth() : null;
-        // Get the reservable bandwidth for the URN matching the node on the "z" side of the edge.
-        ReservableBandwidthE zBandwidth = urnMap.get(edge.getZ().getUrn()) != null ?
-                urnMap.get(edge.getZ().getUrn()).getReservableBandwidth() : null;
-
-
-        // At least one of the two has reservable bandwidth, so check the valid nodes to determine
-        // If they have sufficient bandwidth. In the case of a (device, port) edge, only the port must be checked.
-        // If it is a (port, port) edge, then both must be checked.
-        boolean aPasses = true;
-        boolean zPasses = true;
-        if(aBandwidth != null){
-            // Get a map of the available Ingress/Egress bandwidth for URN a
-            Map<String, Integer> aAvailBwMap = getBwAvailabilityForUrn(urnMap.get(edge.getA().getUrn()), aBandwidth, resvBwMap);
-            aPasses = aAvailBwMap.get("Egress") >= azBw && aAvailBwMap.get("Ingress") >= zaBw;
-        }
-        if(zBandwidth != null){
-            // Get a map of the available Ingress/Egress bandwidth for URN z
-            Map<String, Integer> zAvailBwMap = getBwAvailabilityForUrn(urnMap.get(edge.getZ().getUrn()), zBandwidth, resvBwMap);
-            zPasses = zAvailBwMap.get("Ingress") >= azBw && zAvailBwMap.get("Egress") >= zaBw;
-        }
-
-        return aPasses && zPasses;
-
-
-    }
-
-    /**
-     * Evaluate an edge to determine if the nodes on either end of the edge support the requested
-     * unidriectional bandwidth. An edge will only fail the test if one or both URNs (corresponding to the nodes):
-     * (1) have valid reservable bandwidth fields, and (2) the URN(s) do not have sufficient available bandwidth
-     * available in the unique direction.
-     * @param edge - The edge to be evaluated.
-     * @param theBw - The requested bandwidth in one direction.
-     * @param urnMap - Map of URN name to UrnE object.
-     * @param resvBwMap - Map of UrnE objects to Lists of Reserved Bandwidth
-     * @return True if there is sufficient reservable bandwidth, False otherwise.
-     */
-    private boolean bwAvailableUni(TopoEdge edge, Integer theBw, Map<String, UrnE> urnMap, Map<UrnE, List<ReservedBandwidthE>> resvBwMap){
-
-        if(!edge.getA().getVertexType().equals(VertexType.PORT) || !edge.getZ().getVertexType().equals(VertexType.PORT))
-            return true;
-
-        // Get the reservable bandwidth for the URN matching the node on the "a" side of the edge.
-        ReservableBandwidthE aBandwidth = urnMap.get(edge.getA().getUrn()) != null ?
-                urnMap.get(edge.getA().getUrn()).getReservableBandwidth() : null;
-        // Get the reservable bandwidth for the URN matching the node on the "z" side of the edge.
-        ReservableBandwidthE zBandwidth = urnMap.get(edge.getZ().getUrn()) != null ?
-                urnMap.get(edge.getZ().getUrn()).getReservableBandwidth() : null;
-
-        // At least one of the two has reservable bandwidth, so check the valid nodes to determine
-        // If they have sufficient bandwidth In the case of a (device, port) edge, only the port must be checked.
-        // If it is a (port, port) edge, then both must be checked.
-        boolean aPasses = true;
-        boolean zPasses = true;
-
-        if(aBandwidth != null)
-        {
-            // Get a map of the available Ingress/Egress bandwidth for URN a
-            Map<String, Integer> aAvailBwMap = getBwAvailabilityForUrn(urnMap.get(edge.getA().getUrn()), aBandwidth, resvBwMap);
-            aPasses = aAvailBwMap.get("Egress") >= theBw;
-        }
-        if(zBandwidth != null)
-        {
-            // Get a map of the available Ingress/Egress bandwidth for URN z
-            Map<String, Integer> zAvailBwMap = getBwAvailabilityForUrn(urnMap.get(edge.getZ().getUrn()), zBandwidth, resvBwMap);
-            zPasses = zAvailBwMap.get("Ingress") >= theBw;
-        }
-
-        return aPasses && zPasses;
-    }
-    /**
-     * Determine how much Ingress/Egress bandwidth is still available at a URN. If the list of reserved bandwidths
-     * is empty, then all of the Reservable Bandwidth at that URN is available. Otherwise,
-     * subtract the sum Ingress/Egress bandwidth from the maximum reservable bandwidth at that URN.
-     * @param bandwidth - ReservableBandwidthE object, which contains the maximum Ingress/Egress bandwidth for a given URN
-     * @param resvBwMap - A Mapping from a URN to a list of Reserved Bandwidths at that URN.
-     * @return A map containing the net available ingress/egress bandwidth at a URN
-     */
-    public Map<String,Integer> getBwAvailabilityForUrn(UrnE urn, ReservableBandwidthE bandwidth, Map<UrnE, List<ReservedBandwidthE>> resvBwMap) {
-        Map<String, Integer> availBw = new HashMap<>();
-        availBw.put("Ingress", bandwidth.getIngressBw());
-        availBw.put("Egress", bandwidth.getEgressBw());
-        if(resvBwMap.containsKey(urn)){
-            List<ReservedBandwidthE> resvBwList = resvBwMap.get(urn);
-            Integer sumIngress = 0;
-            Integer sumEgress = 0;
-            for(ReservedBandwidthE resv : resvBwList){
-                sumIngress += resv.getInBandwidth();
-                sumEgress += resv.getEgBandwidth();
-            }
-            availBw.put("Ingress", Math.max(bandwidth.getIngressBw() - sumIngress, 0));
-            availBw.put("Egress", Math.max(bandwidth.getEgressBw() - sumEgress, 0));
-        }
-        return availBw;
-    }
-
-    /**
-     * Return a pruned set of edges where the nodes on either end of the edge support at least one of the specified VLANs.
-     * A map of URNs are used to retrive the reservable VLAN sets from nodes (where applicable). Builds a mapping from
-     * each available VLAN id to the set of edges that support that ID. Using this mapping, the largest set of edges
-     * that supports a requested VLAN id (or any VLAN id if none are specified) is returned.
-     * @param availableEdges - The set of currently available edges, which will be pruned further using VLAN tags.
-     * @param urnMap - Map of URN name to UrnE object.
-     * @param vlans - Requested VLAN ranges. Any VLAN ID within those ranges can be accepted.
-     * @param resvVlanMap - Map of UrnE objects to a List<> of Reserved VLAN tags.
-     * @return The input edges, pruned using the input set of VLAN tags.
-     */
-    private Set<TopoEdge> findEdgesWithAvailableVlans(Set<TopoEdge> availableEdges, Map<String, UrnE> urnMap,
-                                                      List<IntRange> vlans, Map<UrnE, List<ReservedVlanE>> resvVlanMap) {
-        // Find a set of matching edges for each available VLAN id
-        Map<Integer, Set<TopoEdge>> edgesPerId = findEdgesPerVlanId(availableEdges, urnMap, resvVlanMap);
-        // Get a set of the requested VLAN ids
-        Set<Integer> idsInRanges = getIntegersFromRanges(vlans);
-        // Find the largest set of TopoEdges that meet the request
-        Set<TopoEdge> bestSet = new HashSet<>();
-        for(Integer id : edgesPerId.keySet()){
-            // Ignore the set of edges where both terminating nodes do not have reservable VLAN fields
-            // Add them to the best set of edges after this loop
-            if(id == -1){
-                continue;
-            }
-            // If the currently considered ID matches the request (or there are no VLANs requested)
-            // and the set of edges supporting this ID are larger than the current best
-            // choose this set of edges
-            if((idsInRanges.contains(id) || idsInRanges.isEmpty()) && edgesPerId.get(id).size() > bestSet.size()){
-                bestSet = edgesPerId.get(id);
-            }
-        }
-        // Add all edges where neither terminating node has reservable VLAN attributes
-        bestSet.addAll(edgesPerId.get(-1));
-        return bestSet;
-    }
-
-    /**
-     * Return all of the VLAN ids contained within the list of VLAN ranges.
-     * @param vlans - Requested VLAN ranges. Any VLAN ID within those ranges can be accepted.
-     * @return The set of VLAN ids making up the input ranges.
-     */
-    public Set<Integer> getIntegersFromRanges(List<IntRange> vlans){
-        return vlans
-                .stream()
-                .map(this::getSetOfNumbersInRange)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toSet());
-    }
-
-    /**
-     * Traverse the set of edges, and create a map of VLAN ID to the edges where that ID is available
-     * @param edges - The set of edges.
-     * @param urnMap - Map of URN name to UrnE object.
-     * @return A (possibly empty) set of VLAN tags that are available across every edge.
-     */
-    public Map<Integer, Set<TopoEdge>> findEdgesPerVlanId(Set<TopoEdge> edges, Map<String, UrnE> urnMap,
-                                                           Map<UrnE, List<ReservedVlanE>> resvVlanMap){
-        // Overlap is used to track all VLAN tags that are available across every edge.
-        Map<Integer, Set<TopoEdge>> edgesPerId = new HashMap<>();
-        edgesPerId.put(-1, new HashSet<>());
-        for(TopoEdge edge : edges){
-            // Overlap is used to track all VLAN tags that are available across both endpoints of an edge
-            Set<Integer> overlap = new HashSet<>();
-            // Get all possible VLAN ranges reservable at the a and z ends of the edge
-            List<IntRange> aRanges = getVlanRangesFromUrn(urnMap, edge.getA().getUrn());
-            List<IntRange> zRanges = getVlanRangesFromUrn(urnMap, edge.getZ().getUrn());
-
-
-
-            // If neither edge has reservable VLAN fields, add the edge to the "-1" VLAN tag list.
-            // These edges do not need to be pruned, and will be added at the end to the best set of edges
-            if(aRanges.isEmpty() && zRanges.isEmpty() || edge.getLayer().equals(Layer.MPLS)){
-                edgesPerId.get(-1).add(edge);
-            }
-            // Otherwise, find the intersection between the VLAN ranges (if any), and add the edge to the list
-            // matching each overlapping VLAN ID.
-            else{
-                // Find what VLAN ids are actually available at A and Z
-                Set<Integer> aAvailableVlanIds = getAvailableVlanIds(urnMap, edge.getA().getUrn(), aRanges, resvVlanMap);
-                Set<Integer> zAvailableVlanIds = getAvailableVlanIds(urnMap, edge.getZ().getUrn(), zRanges, resvVlanMap);
-                // Find the intersection of those two set of VLAN ranges
-                overlap = addToOverlap(overlap, aAvailableVlanIds);
-                overlap = addToOverlap(overlap, zAvailableVlanIds);
-
-
-                // For overlapping IDs, put that edge into the map
-                for(Integer id: overlap){
-                    if(!edgesPerId.containsKey(id)){
-                        edgesPerId.put(id, new HashSet<>());
-                    }
-                    edgesPerId.get(id).add(edge);
-                }
-            }
-
-        }
-        return edgesPerId;
-    }
-
-    /**
-     * Get all VLAN IDs available at a URN based on the possible reservable ranges and the currently reserved IDs.
-     * @param urnMap - Mapping of URN string to UrnE objects
-     * @param urn - The currently considered URN string
-     * @param ranges - List of IntRanges, representing all ranges of VLAN IDs supported at this URN
-     * @param resvVlanMap - A mapping representing the Reserved VLANs at a URN
-     * @return Set of VLAN IDs that are both supported and not reserved at a URN
-     */
-    public Set<Integer> getAvailableVlanIds(Map<String, UrnE> urnMap, String urn, List<IntRange> ranges,
-                                             Map<UrnE, List<ReservedVlanE>> resvVlanMap) {
-        // Get the supported reservable VLAN IDs
-        Set<Integer> reservableVlanIds = getIntegersFromRanges(ranges);
-
-        UrnE aUrn = urnMap.get(urn);
-        // If this URN is in the reserved VLAN map
-        if(resvVlanMap.containsKey(aUrn)) {
-            // Get the reserved VLAN IDs
-            List<Integer> resvVlanIds = resvVlanMap
-                    .get(aUrn)
-                    .stream()
-                    .map(ReservedVlanE::getVlan)
-                    .collect(Collectors.toList());
-
-            // Return the supported IDs that are not reserved
-            return reservableVlanIds
-                    .stream()
-                    .filter(id -> !resvVlanIds.contains(id))
-                    .collect(Collectors.toSet());
-        }
-        else{
-            return reservableVlanIds;
-        }
-    }
-
-    /**
-     * Using the list of URNs and the URN string, find the matching UrnE object and retrieve all of its
-     * reservable IntRanges.
-     * @param urnMap - Map of URN name to UrnE object.
-     * @param matchingUrn - String representation of the desired URN.
-     * @return - All IntRanges supported at the URN.
-     */
-    public List<IntRange> getVlanRangesFromUrn(Map<String, UrnE> urnMap, String matchingUrn){
-        if(urnMap.get(matchingUrn) == null || urnMap.get(matchingUrn).getReservableVlans() == null)
-            return new ArrayList<>();
-        return urnMap.get(matchingUrn)
-                .getReservableVlans()
-                .getVlanRanges()
-                .stream()
-                .map(IntRangeE::toDtoIntRange)
-                .collect(Collectors.toList());
-    }
-
-
-    /**
-     * Iterate through the set of overlapping VLAN tags, keep the elements in that set which are also
-     * contained in every IntRange passed in.
-     * @param overlap - The set of overlapping VLAN tags.
-     * @param other - Another set of VLAN tags, to be overlapped with the current overlapping set.
-     * @return The (possibly reduced) set of overlapping VLAN tags.
-     */
-    public Set<Integer> addToOverlap(Set<Integer> overlap, Set<Integer> other){
-        // If there are no ranges available, just return the current overlap set
-        if(other.isEmpty()){
-            return overlap;
-        }
-        // If the overlap does not already have elements, add all of the tags retrieved from this range
-        if(overlap.isEmpty()){
-            overlap.addAll(other);
-        }else{
-            // Otherwise, find the intersection between the current overlap and the tags retrieved from this range
-            overlap.retainAll(other);
-        }
-        return overlap;
-    }
-
-    /**
-     * Retrieve a set of all Integers that fall within the specified IntRange.
-     * @param aRange - The specified IntRange
-     * @return The set of Integers contained within the range.
-     */
-    public Set<Integer> getSetOfNumbersInRange(IntRange aRange) {
-        Set<Integer> numbers = new HashSet<>();
-        for(Integer num = aRange.getFloor(); num <= aRange.getCeiling(); num++){
-            numbers.add(num);
-        }
-        return numbers;
-    }
-
-    /**
-     * Get the requested set of VLAN tags from a junction by streaming through the fixtures in the junction.
-     * @param junction - The requested VLAN junction.
-     * @return The set of VLAN tags (Integers) requested for fixtures at that junction.
-     */
-    public List<IntRange> getVlansFromJunction(RequestedVlanJunctionE junction){
-        // Stream through the junction's fixtures, map the requested VLAN expression to a set of Integers
-        return junction.getFixtures().stream()
-                .map(RequestedVlanFixtureE::getVlanExpression)
-                .map(this::getIntRangesFromString)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * Given a list of strings, convert all valid strings into IntRanges.
-     * @param vlans - Requested VLAN ranges. Any VLAN ID within those ranges can be accepted.
-     * @return A list of IntRanges, each representing a range of VLAN ID values parsed from a string.
-     */
-    public List<IntRange> getIntRangesFromString(String vlans){
-        if(IntRangeParsing.isValidIntRangeInput(vlans)){
-            try {
-                return IntRangeParsing.retrieveIntRanges(vlans);
-            }catch(Exception e){
-                return new ArrayList<>();
-            }
-        }
-        return new ArrayList<>();
     }
 
 }

--- a/core/src/main/java/net/es/oscars/pce/TopPCE.java
+++ b/core/src/main/java/net/es/oscars/pce/TopPCE.java
@@ -34,6 +34,12 @@ public class TopPCE {
     @Autowired
     private NonPalindromicalPCE nonPalindromicPCE;
 
+    @Autowired
+    private VlanService vlanService;
+
+    @Autowired
+    private BandwidthService bwService;
+
     /**
      * Given a requested Blueprint (made up of a VLAN or Layer3 Flow) and a Schedule Specification, attempt
      * to reserve available resources to meet the demand. If it is not possible, return an empty Optional<ReservedBlueprintE>
@@ -66,11 +72,11 @@ public class TopPCE {
         for(RequestedVlanJunctionE reqJunction : req_f.getJunctions())
         {
             // Update list of reserved bandwidths
-            List<ReservedBandwidthE> rsvBandwidths = transPCE.createReservedBandwidthList(simpleJunctions, reservedMplsPipes,
+            List<ReservedBandwidthE> rsvBandwidths = bwService.createReservedBandwidthList(simpleJunctions, reservedMplsPipes,
                     reservedEthPipes, schedSpec);
 
             // Update list of reserved VLAN IDs
-            List<ReservedVlanE> rsvVlans = transPCE.createReservedVlanList(simpleJunctions, reservedEthPipes, schedSpec);
+            List<ReservedVlanE> rsvVlans = vlanService.createReservedVlanList(simpleJunctions, reservedEthPipes, schedSpec);
 
             ReservedVlanJunctionE junction = transPCE.reserveSimpleJunction(reqJunction, schedSpec, simpleJunctions,
                     rsvBandwidths, rsvVlans);
@@ -146,11 +152,11 @@ public class TopPCE {
         for(RequestedVlanPipeE pipe: pipes){
 
             // Update list of reserved bandwidths
-            List<ReservedBandwidthE> rsvBandwidths = transPCE.createReservedBandwidthList(simpleJunctions, reservedMplsPipes,
+            List<ReservedBandwidthE> rsvBandwidths = bwService.createReservedBandwidthList(simpleJunctions, reservedMplsPipes,
                     reservedEthPipes, schedSpec);
 
             // Update list of reserved VLAN IDs
-            List<ReservedVlanE> rsvVlans = transPCE.createReservedVlanList(simpleJunctions, reservedEthPipes, schedSpec);
+            List<ReservedVlanE> rsvVlans = vlanService.createReservedVlanList(simpleJunctions, reservedEthPipes, schedSpec);
 
             // Find the shortest path for the pipe, build a map for the AZ and ZA path
             Map<String, List<TopoEdge>> eroMapForPipe = findShortestConstrainedPath(pipe, schedSpec, rsvBandwidths,

--- a/core/src/main/java/net/es/oscars/pce/TranslationPCE.java
+++ b/core/src/main/java/net/es/oscars/pce/TranslationPCE.java
@@ -2,6 +2,8 @@ package net.es.oscars.pce;
 
 
 import lombok.extern.slf4j.Slf4j;
+import net.es.oscars.dto.pss.EthFixtureType;
+import net.es.oscars.dto.pss.EthJunctionType;
 import net.es.oscars.pss.PCEAssistant;
 import net.es.oscars.pss.PSSException;
 import net.es.oscars.resv.dao.ReservedBandwidthRepository;
@@ -11,7 +13,6 @@ import net.es.oscars.resv.ent.*;
 import net.es.oscars.topo.beans.TopoEdge;
 import net.es.oscars.topo.beans.TopoVertex;
 import net.es.oscars.topo.dao.UrnRepository;
-import net.es.oscars.topo.ent.IntRangeE;
 import net.es.oscars.topo.ent.UrnE;
 import net.es.oscars.topo.enums.DeviceModel;
 import net.es.oscars.topo.enums.Layer;
@@ -33,22 +34,13 @@ public class TranslationPCE {
     private TopoService topoService;
 
     @Autowired
-    private ReservedBandwidthRepository bwRepo;
-
-    @Autowired
-    private ReservedVlanRepository vlanRepo;
-
-    @Autowired
-    private ReservedPssResourceRepository pssResourceRepo;
-
-    @Autowired
     private UrnRepository urnRepository;
 
     @Autowired
-    private PruningService pruningService;
+    private VlanService vlanService;
 
     @Autowired
-    private VlanSelectionService vlanService;
+    private BandwidthService bwService;
 
     /**
      * Creates a ReservedVlanJunctionE given a request for ingress/egress traffic within a device.
@@ -79,7 +71,7 @@ public class TranslationPCE {
         }
 
         // Create a reserved junction with an empty set of fixtures / PSS resources
-        ReservedVlanJunctionE rsv_j = pceAssistant.createReservedJunction(urn, new HashSet<>(), new HashSet<>(),
+        ReservedVlanJunctionE rsv_j = createReservedJunction(urn, new HashSet<>(), new HashSet<>(),
                 pceAssistant.decideJunctionType(urn.getDeviceModel()));
 
         // Select a VLAN ID for this junction
@@ -89,7 +81,7 @@ public class TranslationPCE {
         }
 
         // Confirm that there is sufficient available bandwidth
-        boolean sufficientBandwidth = confirmSufficientBandwidth(req_j, reservedBandwidths);
+        boolean sufficientBandwidth = bwService.confirmSufficientBandwidth(req_j, reservedBandwidths);
         if(!sufficientBandwidth){
             return null;
         }
@@ -98,12 +90,12 @@ public class TranslationPCE {
         // and store them in a Reserved Fixture
         Set<RequestedVlanFixtureE> reqFixtures = req_j.getFixtures();
         for(RequestedVlanFixtureE reqFix : reqFixtures){
-            ReservedBandwidthE rsvBw = pceAssistant.createReservedBandwidth(reqFix.getPortUrn(), reqFix.getInMbps(),
+            ReservedBandwidthE rsvBw = createReservedBandwidth(reqFix.getPortUrn(), reqFix.getInMbps(),
                     reqFix.getEgMbps(), sched);
 
-            ReservedVlanE rsvVlan = pceAssistant.createReservedVlan(reqFix.getPortUrn(), fixVlanMap.get(reqFix), sched);
+            ReservedVlanE rsvVlan = createReservedVlan(reqFix.getPortUrn(), fixVlanMap.get(reqFix), sched);
 
-            ReservedVlanFixtureE rsvFix = pceAssistant.createReservedFixture(reqFix.getPortUrn(), new HashSet<>(),
+            ReservedVlanFixtureE rsvFix = createReservedFixture(reqFix.getPortUrn(), new HashSet<>(),
                     rsvVlan, rsvBw, pceAssistant.decideFixtureType(reqFix.getPortUrn().getDeviceModel()));
 
             // Add the fixtures to the Reserved Junction
@@ -155,16 +147,16 @@ public class TranslationPCE {
 
         // Get map of "Ingress" and "Egress" bandwidth availability
         Map<UrnE, Map<String, Integer>> availBwMap;
-        availBwMap = createBandwidthAvailabilityMap(reservedBandwidths);
+        availBwMap = bwService.createBandwidthAvailabilityMap(reservedBandwidths);
 
         // Returns a mapping from topovertices (ports) to an "Ingress"/"Egress" map of the total Ingress/Egress
         // Requested bandwidth at that port across both the azERO and the zaERO
-        Map<TopoVertex, Map<String, Integer>> requestedBandwidthMap = createRequestedBandwidthMap(azERO, zaERO, azMbps, zaMbps);
+        Map<TopoVertex, Map<String, Integer>> requestedBandwidthMap = bwService.createRequestedBandwidthMap(azERO, zaERO, azMbps, zaMbps);
 
         // Confirm that there is sufficient bandwidth to meet the request (given what has been reserved so far)
         // Palindromic EROs -- evaluate both directions at each port - traffic flows both ways
-        if(this.palindromicEros(azERO, zaERO)){
-            boolean sufficientBw = checkForSufficientBw(urnMap, azMbps, zaMbps, azERO, zaERO, availBwMap);
+        if(pceAssistant.palindromicEros(azERO, zaERO)){
+            boolean sufficientBw = bwService.checkForSufficientBw(urnMap, azMbps, zaMbps, azERO, zaERO, availBwMap);
             if(!sufficientBw)
                 throw new PCEException("Insufficient Bandwidth to meet requested pipe" + reqPipe.toString() +
                         " given previous reservations in flow");
@@ -172,9 +164,9 @@ public class TranslationPCE {
         // Non-Palindromic EROs -- evaluate the ports in each ERO just for traffic in the AZ or ZA direction
         else{
             // Consider A->Z ERO with bwAZ
-            boolean sufficientBwAZ = checkForSufficientBwUni(urnMap, azMbps, azERO, availBwMap);
+            boolean sufficientBwAZ = bwService.checkForSufficientBwUni(urnMap, azMbps, azERO, availBwMap);
             // Consider Z->A ERO with bwZA
-            boolean sufficientBwZA = checkForSufficientBwUni(urnMap, zaMbps, zaERO, availBwMap);
+            boolean sufficientBwZA = bwService.checkForSufficientBwUni(urnMap, zaMbps, zaERO, availBwMap);
             if(!sufficientBwAZ)
             {
                 throw new PCEException("Insufficient Bandwidth to meet requested A->Z pipe" + reqPipe.toString() +
@@ -203,7 +195,7 @@ public class TranslationPCE {
                 }
                 UrnE biUrn = urnMap.get(biPort.getUrn());
 
-                if(!sufficientBandwidthAtUrn(biUrn, availBwMap, azMbps, zaMbps)){
+                if(!bwService.sufficientBandwidthAtUrn(biUrn, availBwMap, azMbps, zaMbps)){
                     throw new PCEException("Insufficient Bandwidth to meet requested pipe" + reqPipe.toString() +
                             " given previous reservations in flow");
                 }
@@ -269,7 +261,7 @@ public class TranslationPCE {
 
             // Create or retrieve A Junction
             if(!junctionMap.containsKey(aVertex)){
-                aJunction = pceAssistant.createJunctionAndFixtures(aVertex, urnMap, deviceModels, reqPipeJunctions,
+                aJunction = createJunctionAndFixtures(aVertex, urnMap, deviceModels, reqPipeJunctions,
                         chosenVlanMap, sched);
                 junctionMap.put(aVertex, aJunction);
             }
@@ -278,7 +270,7 @@ public class TranslationPCE {
             }
             // Create Z Junction
             if(!junctionMap.containsKey(zVertex)){
-                zJunction = pceAssistant.createJunctionAndFixtures(zVertex, urnMap, deviceModels, reqPipeJunctions,
+                zJunction = createJunctionAndFixtures(zVertex, urnMap, deviceModels, reqPipeJunctions,
                         chosenVlanMap, sched);
                 junctionMap.put(zVertex, zJunction);
             }
@@ -289,7 +281,7 @@ public class TranslationPCE {
             DeviceModel aModel = deviceModels.get(aJunction.getDeviceUrn().getUrn());
             DeviceModel zModel = deviceModels.get(zJunction.getDeviceUrn().getUrn());
 
-            Set<ReservedBandwidthE> pipeBandwidths = pceAssistant.createReservedBandwidthForEROs(pipeEroMap.get("AZ"),
+            Set<ReservedBandwidthE> pipeBandwidths = createReservedBandwidthForEROs(pipeEroMap.get("AZ"),
                     pipeEroMap.get("ZA"), urnMap, requestedBandwidthMap, sched);
 
 
@@ -307,7 +299,7 @@ public class TranslationPCE {
             }
             // ETHERNET
             else{
-                Set<ReservedVlanE> pipeVlans = pceAssistant.createReservedVlanForEROs(pipeEroMap.get("AZ"),
+                Set<ReservedVlanE> pipeVlans = createReservedVlanForEROs(pipeEroMap.get("AZ"),
                         pipeEroMap.get("ZA"), urnMap, chosenVlanMap, sched);
 
                 ReservedEthPipeE ethPipe = ReservedEthPipeE.builder()
@@ -327,563 +319,210 @@ public class TranslationPCE {
     }
 
 
+
     /**
-     * Build a map of the available bandwidth at each URN. For each URN, there is a map of "Ingress" and "Egress"
-     * bandwidth available. Only port URNs can be found in this map.
-     * @param rsvBandwidths - A list of all bandwidth reserved so far
-     * @return A mapping of URN to Ingress/Egress bandwidth availability
+     * Given two lists of EROS in the AZ and ZA direction, a map of URNs, a map of the requested bandwidth at each URN,
+     * and the requested schedule, return a combined set of reserved bandwidth objects for the AZ and ZA paths
+     * @param az - The AZ vertices
+     * @param za - The ZA vertices
+     * @param urnMap - A mapping of URN string to URN object
+     * @param requestedBandwidthMap - A mapping of Vertex objects to "Ingress"/"Egress" requested bandwidth
+     * @param sched - THe requested schedule
+     * @return A set of all reserved bandwidth for every port (across both paths)
      */
-    private Map<UrnE, Map<String, Integer>> createBandwidthAvailabilityMap(List<ReservedBandwidthE> rsvBandwidths){
-        // Build a map, allowing us to retrieve a list of ReservedBandwidth given the associated URN
-        Map<UrnE, List<ReservedBandwidthE>> resvBwMap = pruningService.buildReservedBandwidthMap(rsvBandwidths);
+    public Set<ReservedBandwidthE> createReservedBandwidthForEROs(List<TopoVertex> az, List<TopoVertex> za,
+                                                                  Map<String, UrnE> urnMap,
+                                                                  Map<TopoVertex, Map<String, Integer>> requestedBandwidthMap,
+                                                                  ScheduleSpecificationE sched) {
+        // Combine the AZ and ZA EROs
+        Set<TopoVertex> combined = new HashSet<>(az);
+        combined.addAll(za);
 
-        // Build a map, allowing us to retrieve the available "Ingress" and "Egress" bandwidth at each associated URN
-        Map<UrnE, Map<String, Integer>> availBwMap = new HashMap<>();
-        urnRepository.findAll()
-                .stream()
-                .filter(urn -> urn.getReservableBandwidth() != null)
-                .forEach(urn -> availBwMap.put(urn, pruningService.getBwAvailabilityForUrn(urn, urn.getReservableBandwidth(), resvBwMap)));
+        // Store the reserved bandwidths
+        Set<ReservedBandwidthE> reservedBandwidths = new HashSet<>();
 
-        return availBwMap;
+        // For each vertex in the combined set, retrieve the requested Ingress/Egress bandwidth, and create a reserved
+        // bandwidth object
+        combined.stream().filter(requestedBandwidthMap::containsKey).forEach(vertex -> {
+            UrnE urn = urnMap.get(vertex.getUrn());
+            Integer reqInMbps = requestedBandwidthMap.get(vertex).get("Ingress");
+            Integer reqEgMbps = requestedBandwidthMap.get(vertex).get("Egress");
+
+            ReservedBandwidthE rsvBw = createReservedBandwidth(urn, reqInMbps, reqEgMbps, sched);
+            reservedBandwidths.add(rsvBw);
+
+        });
+
+        // Return the set
+        return reservedBandwidths;
     }
 
     /**
-     * Given a set of reserved junctions and reserved MPLS / ETHERNET pipes, extract the reserved bandwidth objects
-     * which fall within the requested schedule period and return them all together as a list
-     * @param reservedJunctions - Set of reserved ethernet junctions
-     * @param reservedMplsPipes - Set of reserved MPLS pipes
-     * @param reservedEthPipes - Set of reserved Ethernet pipes
-     * @param sched - The requested schedule (start and end date)
-     * @return List of all reserved bandwidth contained within reserved pipes and the reserved repository.
+     * Given two lists of EROS in the AZ and ZA direction, a map of URNs, a chosen vlan ID,
+     * and the requested schedule, return a combined set of reserved VLAN objects for the AZ and ZA paths
+     * @param az - The AZ vertices
+     * @param za - The ZA vertices
+     * @param urnMap - A mapping of URN string to URN object
+     * @param vlanMap - A mapping of URN object to assigned VLAN ID
+     * @param sched - THe requested schedule
+     * @return A set of all reserved VLAN objects for every port (across both paths)
      */
-    public List<ReservedBandwidthE> createReservedBandwidthList(Set<ReservedVlanJunctionE> reservedJunctions,
-                                                                 Set<ReservedMplsPipeE> reservedMplsPipes,
-                                                                 Set<ReservedEthPipeE> reservedEthPipes,
-                                                                 ScheduleSpecificationE sched){
-        // Retrieve all bandwidth reserved so far from pipes & junctions
-        List<ReservedBandwidthE> rsvBandwidths = retrieveReservedBandwidths(reservedJunctions);
-        rsvBandwidths.addAll(retrieveReservedBandwidthsFromMplsPipes(reservedMplsPipes));
-        rsvBandwidths.addAll(retrieveReservedBandwidthsFromEthPipes(reservedEthPipes));
-        rsvBandwidths.addAll(pruningService.getReservedBandwidth(sched.getNotBefore(), sched.getNotAfter()));
-
-        return rsvBandwidths;
-    }
-
-    /**
-     * Given a set of reserved junctions and reserved ethernet pipes, retrieve all reserved VLAN objects
-     * within the specified schedule period.
-     * @param reservedJunctions - Set of reserved junctions
-     * @param reservedEthPipes - Set of reserved ethernet pipes
-     * @param sched - Requested schedule
-     * @return
-     */
-    public List<ReservedVlanE> createReservedVlanList(Set<ReservedVlanJunctionE> reservedJunctions,
-                                                       Set<ReservedEthPipeE> reservedEthPipes,
-                                                       ScheduleSpecificationE sched){
-
-        // Retrieve all VLAN IDs reserved so far from junctions & pipes
-        List<ReservedVlanE> rsvVlans = retrieveReservedVlans(reservedJunctions);
-        rsvVlans.addAll(retrieveReservedVlansFromEthPipes(reservedEthPipes));
-        rsvVlans.addAll(pruningService.getReservedVlans(sched.getNotBefore(), sched.getNotAfter()));
-
-        return rsvVlans;
-    }
-
-    /**
-     * Build a map of the requested bandwidth at each port TopoVertex contained within the az and za EROs.
-     * @param azERO - The path in the AZ direction
-     * @param zaERO - The path in the ZA direction
-     * @param azMbps - The requested bandwidth in the AZ direction
-     * @param zaMbps - The requested bandwidth in the ZA direction
-     * @return A mapping from TopoVertex (ports only) to requested "Ingress" and "Egress" bandwidth
-     */
-    private Map<TopoVertex, Map<String, Integer>> createRequestedBandwidthMap(List<TopoEdge> azERO, List<TopoEdge> zaERO,
-                                                                             Integer azMbps, Integer zaMbps){
-        // Map a port node to a map of "Ingress" and "Egress" requested bandwidth values
-        Map<TopoVertex, Map<String, Integer>> requestedBandwidthMap = new HashMap<>();
-
-        // Iterate through the AZ edges, update the map for each port node found in the path
-        for(TopoEdge azEdge : azERO){
-            updateRequestedBandwidthMap(azEdge, azMbps, requestedBandwidthMap);
-        }
-
-        // Iterate through the ZA edges, update the map for each port node in the path
-        for(TopoEdge zaEdge : zaERO){
-            updateRequestedBandwidthMap(zaEdge, zaMbps, requestedBandwidthMap);
-        }
-
-        return requestedBandwidthMap;
-    }
-
-    /**
-     * Update the values in a mapping of port vertices to requested Ingress/Egress bandwidth.
-     * @param edge - An edge, with a vertex on the "A" side and on the "Z" side
-     * @param bandwidth - The requested bandwidth in one direction
-     * @param requestedBandwidthMap - The soon-to-be updated map of requested bandwidth per port
-     */
-    private void updateRequestedBandwidthMap(TopoEdge edge, Integer bandwidth,
-                                             Map<TopoVertex, Map<String, Integer>> requestedBandwidthMap){
-
-        // Retrieve the "A" side of the edge
-        TopoVertex nodeA = edge.getA();
-        // Retrieve the "Z" side of the edge
-        TopoVertex nodeZ = edge.getZ();
-
-        // Add node A to the map if it is a port and it is not already in the map
-        if(nodeA.getVertexType().equals(VertexType.PORT) && !requestedBandwidthMap.containsKey(nodeA)){
-            requestedBandwidthMap.put(nodeA, makeInitialBandwidthMap());
-        }
-        // Add node Z to the map if it is a port and it is not already in the map
-        if(nodeZ.getVertexType().equals(VertexType.PORT) && !requestedBandwidthMap.containsKey(nodeZ)){
-            requestedBandwidthMap.put(nodeZ, makeInitialBandwidthMap());
-        }
-
-        // All Cases: Add the requested bandwidth to the amount already stored in the map
-        // Case 1: portA -> portZ -- portA = egress, portZ = ingress
-        /*
-        if(nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
-        {
-            Integer updatedEgress = requestedBandwidthMap.get(nodeA).get("Egress") + bandwidth;
-            requestedBandwidthMap.get(nodeA).put("Egress", updatedEgress);
-
-            Integer updatedIngress = requestedBandwidthMap.get(nodeZ).get("Ingress") + bandwidth;
-            requestedBandwidthMap.get(nodeZ).put("Ingress", updatedIngress);
-        }*/
-        // Case 2: portA -> deviceZ -- portA = ingress
-        if(nodeA.getVertexType().equals(VertexType.PORT) && !nodeZ.getVertexType().equals(VertexType.PORT))
-        {
-            Integer updatedIngress = requestedBandwidthMap.get(nodeA).get("Ingress") + bandwidth;
-            requestedBandwidthMap.get(nodeA).put("Ingress", updatedIngress);
-        }
-        // Case 3: deviceA -> portZ -- portZ = egress
-        else if(!nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
-        {
-            Integer updatedEgress = requestedBandwidthMap.get(nodeZ).get("Egress") + bandwidth;
-            requestedBandwidthMap.get(nodeZ).put("Egress", updatedEgress);
-        }
-
-    }
-
-    /**
-     * Build an initial map of requested bandwidth in the Ingress and Egress directions
-     * @return A new map with 0 Ingress and Egress bandwidth.
-     */
-    private Map<String, Integer> makeInitialBandwidthMap(){
-        Map<String, Integer> initialMap = new HashMap<>();
-        initialMap.put("Ingress", 0);
-        initialMap.put("Egress", 0);
-        return initialMap;
-    }
-
-    /**
-     * Confirm that the two EROs are identical
-     * @param azERO - A path in one direction
-     * @param zaERO - A path in another direction
-     * @return True if they are identical, False otherwise.
-     */
-    private boolean palindromicEros(List<TopoEdge> azERO, List<TopoEdge> zaERO)
-    {
-        Set<TopoVertex> azVertices = new HashSet<>();
-        Set<TopoVertex> zaVertices = new HashSet<>();
-
-        for(TopoEdge azEdge : azERO)
-        {
-            azVertices.add(azEdge.getA());
-            azVertices.add(azEdge.getZ());
-        }
-
-        for(TopoEdge zaEdge : zaERO)
-        {
-            zaVertices.add(zaEdge.getA());
-            zaVertices.add(zaEdge.getZ());
-        }
-
-        if(azVertices.size() != zaVertices.size())
-            return false;
-
-        for(TopoVertex oneVert : azVertices)
-        {
-            if(!zaVertices.contains(oneVert))
-                return false;
-        }
-
-        Set<TopoVertex> azPorts = azVertices
-                .stream()
-                .filter(v -> v.getVertexType().equals(VertexType.PORT))
-                .collect(Collectors.toSet());
-        Set<TopoVertex> zaPorts = zaVertices
-                .stream()
-                .filter(v -> v.getVertexType().equals(VertexType.PORT))
-                .collect(Collectors.toSet());
-
-        if(azPorts.size() != zaPorts.size())
-            return false;
-
-        // Now see if all ports are traversed in both the ingress and egress directions
-        Set<TopoVertex> ingressPorts = new HashSet<>();
-        Set<TopoVertex> egressPorts = new HashSet<>();
-
-        // Identify which ports are used as ingress vs the ones that are used as egress
-        for(TopoEdge azEdge : azERO)
-        {
-            TopoVertex nodeA = azEdge.getA();
-            TopoVertex nodeZ = azEdge.getZ();
-
-            // Case 1: portA -> portZ -- portA = egress, portZ = ingress
-            if(nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
-            {
-                egressPorts.add(nodeA);
-                ingressPorts.add(nodeZ);
-            }
-            // Case 2: portA -> deviceZ -- portA = ingress
-            else if(nodeA.getVertexType().equals(VertexType.PORT) && !nodeZ.getVertexType().equals(VertexType.PORT))
-            {
-                ingressPorts.add(nodeA);
-            }
-            // Case 3: deviceA -> portZ -- portZ = egress
-            else if(!nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
-            {
-                egressPorts.add(nodeZ);
-            }
-        }
-
-        // repeat above for Z->A
-        for(TopoEdge zaEdge : zaERO)
-        {
-            TopoVertex nodeA = zaEdge.getA();
-            TopoVertex nodeZ = zaEdge.getZ();
-
-            // Case 1: portA -> portZ -- portA = egress, portZ = ingress
-            if(nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
-            {
-                egressPorts.add(nodeA);
-                ingressPorts.add(nodeZ);
-            }
-            // Case 2: portA -> deviceZ -- portA = ingress
-            else if(nodeA.getVertexType().equals(VertexType.PORT) && !nodeZ.getVertexType().equals(VertexType.PORT))
-            {
-                ingressPorts.add(nodeA);
-            }
-            // Case 3: deviceA -> portZ -- portZ = egress
-            else if(!nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
-            {
-                egressPorts.add(nodeZ);
-            }
-        }
-
-        // Now check to see if all ports used are both ingress and egress -- if so, palindromic port usage!
-        if(ingressPorts.size() != egressPorts.size())
-            return false;
-
-        if(ingressPorts.size() != azPorts.size())
-            return false;
-
-        for(TopoVertex onePort : azPorts)
-        {
-            if(!(zaPorts.contains(onePort) && ingressPorts.contains(onePort) && egressPorts.contains(onePort)))
-                return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Examine all AZ and ZA edges, confirm that the requested bandwidth can be supported given the available bandwidth.
-     * @param urnMap - A map of URN string to URN objects
-     * @param azERO - The path in the A->Z direction
-     * @param zaERO - The path in the Z->A direction
-     * @param availBwMap - A map of bandwidth availability
-     * @return True, if there is sufficient bandwidth across all edges. False, otherwise.
-     */
-    private boolean checkForSufficientBw(Map<String, UrnE> urnMap, Integer azMbps, Integer zaMbps, List<TopoEdge> azERO,
-                                         List<TopoEdge> zaERO, Map<UrnE, Map<String, Integer>> availBwMap) {
-
-        // For the AZ direction, fail the test if there is insufficient bandwidth
-        if(!sufficientBandwidthForERO(azERO, urnMap, availBwMap, azMbps, zaMbps)){
-            return false;
-        }
-
-        // For each ZA direction, fail the test if there is insufficient bandwidth
-        return sufficientBandwidthForERO(zaERO, urnMap, availBwMap, azMbps, zaMbps);
-    }
-
-    /**
-     * Examine all edges, confirm that the requested bandwidth can be supported given the available bandwidth.
-     * @param urnMap - A map of URN string to URN objects
-     * @param bwMbps - The requested bandwidth (in one direction)
-     * @param availBwMap - A map of bandwidth availability
-     * @return True, if there is sufficient bandwidth across all edges. False, otherwise.
-     */
-    private boolean checkForSufficientBwUni(Map<String, UrnE> urnMap, Integer bwMbps, List<TopoEdge> ERO,
-                                            Map<UrnE, Map<String, Integer>> availBwMap){
-        // For the AZ direction, fail the test if there is insufficient bandwidth
-        return sufficientBandwidthForEROUni(ERO, urnMap, availBwMap, bwMbps);
-    }
-
-    /**
-     * Given a particular list of edges, iterate and confirm that there is sufficient bandwidth available in both directions
-     * @param ERO - A series of edges
-     * @param urnMap - A mapping of URN strings to URN objects
-     * @param availBwMap - A mapping of URN objects to lists of available bandwidth for that URN
-     * @param azMbps - The bandwidth in the AZ direction
-     * @param zaMbps - The bandwidth the ZA direction
-     * @return True, if the segment can support the requested bandwidth. False, otherwise.
-     */
-    private boolean sufficientBandwidthForERO(List<TopoEdge> ERO, Map<String, UrnE> urnMap,
-                                              Map<UrnE, Map<String, Integer>> availBwMap, Integer azMbps,
-                                              Integer zaMbps){
-        // For each edge in that list
-        for(TopoEdge edge : ERO){
-            // Retrieve the URNs
-            String urnStringA = edge.getA().getUrn();
-            String urnStringZ = edge.getZ().getUrn();
-            if(!urnMap.containsKey(urnStringA) || !urnMap.containsKey(urnStringZ)){
-                return false;
-            }
-            UrnE urnA = urnMap.get(urnStringA);
-            UrnE urnZ = urnMap.get(urnStringZ);
-
-            // If URN A has reservable bandwidth, confirm that there is enough available
-            if(urnA.getReservableBandwidth() != null){
-                if(!sufficientBandwidthAtUrn(urnA, availBwMap, azMbps, zaMbps)){
-                    return false;
-                }
-            }
-
-            // If URN Z has reservable bandwidth, confirm that there is enough available
-            if(urnZ.getReservableBandwidth() != null){
-                if(!sufficientBandwidthAtUrn(urnZ, availBwMap, azMbps, zaMbps)){
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-
-    /**
-     * Given a list of edges, confirm that there is sufficient bandwidth available in the one direction
-     * @param ERO - A series of edges
-     * @param urnMap - A mapping of URN strings to URN objects
-     * @param availBwMap - A mapping of URN objects to lists of reserved bandwidth for that URN
-     * @param bwMbps - The bandwidth in the specified direction
-     * @return True, if the segment can support the requested bandwidth. False, otherwise.
-     */
-    private boolean sufficientBandwidthForEROUni(List<TopoEdge> ERO, Map<String, UrnE> urnMap,
-                                                 Map<UrnE, Map<String, Integer>> availBwMap, Integer bwMbps)
-    {
-        // For each edge in that list
-        for(TopoEdge edge : ERO)
-        {
-            Map<UrnE, Boolean> urnIngressDirectionMap = new HashMap<>();
-            TopoVertex nodeA = edge.getA();
-            TopoVertex nodeZ = edge.getZ();
-            String urnStringA = nodeA.getUrn();
-            String urnStringZ = nodeZ.getUrn();
-
-            if(!urnMap.containsKey(urnStringA) || !urnMap.containsKey(urnStringZ))
-            {
-                return false;
-            }
-
-            UrnE urnA = urnMap.get(urnStringA);
-            UrnE urnZ = urnMap.get(urnStringZ);
-
-            // From Port to Device -- Consider Ingress direction for this Port
-            if(nodeA.getVertexType().equals(VertexType.PORT) && !nodeZ.getVertexType().equals(VertexType.PORT))
-            {
-                urnIngressDirectionMap.put(urnA, true);
-            }
-            // From Device to Port -- Consider Egress direction for this Port
-            else if(!nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
-            {
-                urnIngressDirectionMap.put(urnZ, false);
-            }
-            // From Port to Port -- Consider Egress for portA, and Ingress for portZ
-            else if(nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
-            {
-                urnIngressDirectionMap.put(urnA, false);
-                urnIngressDirectionMap.put(urnZ, true);
-            }
-
-            // If URN A has reservable bandwidth, confirm that there is enough available
-            if(urnA.getReservableBandwidth() != null)
-            {
-                boolean ingressDirection = urnIngressDirectionMap.get(urnA);
-
-                if(!sufficientBandwidthAtUrnUni(urnA, availBwMap, bwMbps, ingressDirection))
-                {
-                    return false;
-                }
-            }
-
-            // If URN Z has reservable bandwidth, confirm that there is enough available
-            if(urnZ.getReservableBandwidth() != null)
-            {
-                boolean ingressDirection = urnIngressDirectionMap.get(urnZ);
-
-                if(!sufficientBandwidthAtUrnUni(urnZ, availBwMap, bwMbps, ingressDirection))
-                {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-
-    /**
-     * Given a specific URN, determine if there is enough bandwidth available to support the requested bandwidth
-     * @param urn - The URN
-     * @param availBwMap - Map of URNs to available Bandwidth
-     * @param inMbps - Requested ingress Mbps
-     * @param egMbps - Requested egress Mbps
-     * @return True, if there is enough available bandwidth at the URN. False, otherwise
-     */
-    private boolean sufficientBandwidthAtUrn(UrnE urn, Map<UrnE, Map<String, Integer>> availBwMap,
-                                             Integer inMbps, Integer egMbps){
-        Map<String, Integer> bwAvail = availBwMap.get(urn);
-        if(bwAvail.get("Ingress") < inMbps || bwAvail.get("Egress") < egMbps){
-            log.error("Insufficient Bandwidth at " + urn.toString() + ". Requested: " +
-                    inMbps + " In and " + egMbps + " Out. Available: " + bwAvail.get("Ingress") +
-                    " In and " + bwAvail.get("Egress") + " Out.");
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Given a specific URN, determine if there is enough bandwidth available to support the requested bandwidth in a specific (ingress/egress) direction
-     * @param urn - The URN
-     * @param availBwMap - Map of URNs to Available Bandwidth
-     * @param bwMbps - Requested Mbps
-     * @param ingressDirection - True if pruning is done based upon port ingress b/w, false if done by egress b/w
-     * @return True, if there is enough available bandwidth at the URN. False, otherwise
-     */
-    private boolean sufficientBandwidthAtUrnUni(UrnE urn, Map<UrnE, Map<String, Integer>> availBwMap,
-                                                Integer bwMbps, boolean ingressDirection){
-        Map<String, Integer> bwAvail = availBwMap.get(urn);
-
-        Integer unidirectionalBW;
-        String direction = "";
-
-        if(ingressDirection)
-        {
-            unidirectionalBW = bwAvail.get("Ingress");
-            direction = " In.";
-        }
-        else
-        {
-            unidirectionalBW = bwAvail.get("Egress");
-            direction = " Out.";
-        }
-
-        if(unidirectionalBW < bwMbps)
-        {
-            log.error("Insufficient Bandwidth at " + urn.toString() + ". Requested: " + bwMbps + direction);
-            return false;
-        }
-
-        return true;
-    }
-
-
-    /**
-     * Confirm that a requested VLAN junction supports the requested bandwidth. Checks each fixture of the junction.
-     * @param req_j - The requested junction.
-     * @param reservedBandwidths - The reserved bandwidth.
-     * @return True, if there is enough bandwidth at every fixture. False, otherwise.
-     */
-    public boolean confirmSufficientBandwidth(RequestedVlanJunctionE req_j, List<ReservedBandwidthE> reservedBandwidths){
-
-        // All requested fixtures on this junction
-        Set<RequestedVlanFixtureE> reqFixtures = req_j.getFixtures();
-
-
-        // Get map of "Ingress" and "Egress" bandwidth availability
-        Map<UrnE, Map<String, Integer>> availBwMap = createBandwidthAvailabilityMap(reservedBandwidths);
-
-        // For each requested fixture,
-        for(RequestedVlanFixtureE reqFix: reqFixtures){
-            // Confirum that there is enough available bandwidth at that URN
-            if(!sufficientBandwidthAtUrn(reqFix.getPortUrn(), availBwMap, reqFix.getInMbps(), reqFix.getEgMbps())){
-                return false;
-            }
-        }
-        return true;
-    }
-
-
-    /**
-     * Retrieve all reserved bandwidths from a set of reserved junctions.
-     * @param junctions - Set of reserved junctions.
-     * @return A list of all bandwidth reserved at those junctions.
-     */
-    public List<ReservedBandwidthE> retrieveReservedBandwidths(Set<ReservedVlanJunctionE> junctions){
-        return junctions
-                .stream()
-                .map(ReservedVlanJunctionE::getFixtures)
-                .flatMap(Collection::stream)
-                .map(ReservedVlanFixtureE::getReservedBandwidth)
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * Retrieve all reserved VLAN IDs from a set of reserved junctions
-     * @param junctions - Set of reserved junctions.
-     * @return A list of all VLAN IDs reserved at those junctions.
-     */
-    public List<ReservedVlanE> retrieveReservedVlans(Set<ReservedVlanJunctionE> junctions){
-        return junctions
-                .stream()
-                .map(ReservedVlanJunctionE::getFixtures)
-                .flatMap(Collection::stream)
-                .map(ReservedVlanFixtureE::getReservedVlan)
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * Retrieve all Reserved Bandwidth from a set of reserved MPLS pipes.
-     * @param reservedPipes - Set of reserved pipes
-     * @return A list of all reserved bandwidth within the set of reserved MPLS pipes.
-     */
-    public List<ReservedBandwidthE> retrieveReservedBandwidthsFromMplsPipes(Set<ReservedMplsPipeE> reservedPipes) {
-        return reservedPipes
-                .stream()
-                .map(ReservedMplsPipeE::getReservedBandwidths)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * Retrieve all Reserved Bandwidth from a set of reserved Ethernet pipes.
-     * @param reservedPipes - Set of reserved pipes
-     * @return A list of all reserved bandwidth within the set of reserved Ethernet pipes.
-     */
-    public List<ReservedBandwidthE> retrieveReservedBandwidthsFromEthPipes(Set<ReservedEthPipeE> reservedPipes) {
-        return reservedPipes
-                .stream()
-                .map(ReservedEthPipeE::getReservedBandwidths)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
-    }
-
-
-
-    /**
-     * Retrieve all Reserved VLAN IDs from a set of reserved pipes.
-     * @param reservedPipes - Set of reserved pipes
-     * @return A list of all reserved VLAN IDs within the set of reserved pipes.
-     */
-    public List<ReservedVlanE> retrieveReservedVlansFromEthPipes(Set<ReservedEthPipeE> reservedPipes) {
-        List<ReservedVlanE> reservedVlans = new ArrayList<>();
-        Set<ReservedVlanJunctionE> junctions = new HashSet<>();
-        for(ReservedEthPipeE pipe : reservedPipes){
-            junctions.add(pipe.getAJunction());
-            junctions.add(pipe.getZJunction());
-            reservedVlans.addAll(pipe.getReservedVlans());
-        }
-        reservedVlans.addAll(retrieveReservedVlans(junctions));
+    public Set<ReservedVlanE> createReservedVlanForEROs(List<TopoVertex> az, List<TopoVertex> za,
+                                                        Map<String, UrnE> urnMap, Map<UrnE, Integer> vlanMap,
+                                                        ScheduleSpecificationE sched) {
+        // Combine the AZ and ZA EROs
+        Set<TopoVertex> combined = new HashSet<>(az);
+        combined.addAll(za);
+
+        // Store the reserved bandwidths
+        Set<ReservedVlanE> reservedVlans = new HashSet<>();
+
+        // For each vertex in the combined set, retrieve the requested Ingress/Egress bandwidth, and create a reserved
+        // bandwidth object
+        combined.stream().filter(vertex -> vertex.getVertexType().equals(VertexType.PORT)).forEach(vertex -> {
+            UrnE urn = urnMap.get(vertex.getUrn());
+
+            ReservedVlanE rsvVlan = createReservedVlan(urn, vlanMap.get(urn), sched);
+            reservedVlans.add(rsvVlan);
+
+        });
+
+        // Return the set
         return reservedVlans;
     }
+
+    /**
+     * Create a Junction and it's associated fixtures given the input parameters.
+     * @param device - The device vertex associated with the junction
+     * @param urnMap - A mapping of URN strings to URN objects
+     * @param deviceModels - A mapping of URN strings to Device Models
+     * @param requestedJunctions - A set of requested junctions - used to determine attributes of junction/fixtures
+     * @param vlanMap - Map of assigned VLANs for each fixture
+     * @param sched - The requested schedule
+     * @return A Reserved Vlan Junction with Reserved Fixtures (if contained in a matching requested junction)
+     * @throws PSSException
+     */
+    public ReservedVlanJunctionE createJunctionAndFixtures(TopoVertex device, Map<String, UrnE> urnMap,
+                                                           Map<String, DeviceModel> deviceModels,
+                                                           Set<RequestedVlanJunctionE> requestedJunctions,
+                                                           Map<UrnE, Integer> vlanMap, ScheduleSpecificationE sched)
+            throws PSSException {
+        // Get this junction's URN, Device Model, and Typing for its Fixtures
+        UrnE aUrn = urnMap.get(device.getUrn());
+        DeviceModel model = deviceModels.get(aUrn.getUrn());
+        EthFixtureType fixType = pceAssistant.decideFixtureType(model);
+
+        // Create the set of Reserved Fixtures by filtering for requested junctions that match the URN
+        log.info(requestedJunctions.stream().filter(reqJunction -> reqJunction.getDeviceUrn().equals(aUrn)).collect(Collectors.toList()).toString());
+        Set<ReservedVlanFixtureE> reservedVlanFixtures = requestedJunctions
+                .stream()
+                .filter(reqJunction -> reqJunction.getDeviceUrn().equals(aUrn))
+                .map(RequestedVlanJunctionE::getFixtures)
+                .flatMap(Collection::stream)
+                .map(reqFix -> createFixtureAndResources(reqFix.getPortUrn(), fixType,
+                        reqFix.getInMbps(), reqFix.getEgMbps(), vlanMap.get(reqFix.getPortUrn()), sched))
+                .collect(Collectors.toSet());
+
+        log.info("Reserved Fixtures at " + aUrn + ": " + reservedVlanFixtures);
+        // Return the Reserved Junction (with the set of reserved VLAN fixtures).
+        return createReservedJunction(aUrn, new HashSet<>(),
+                reservedVlanFixtures, pceAssistant.decideJunctionType(model));
+    }
+
+    /**
+     * Create a Reserved Fixtures and it's associated resources (VLAN and Bandwidth) using the input.
+     * @param portUrn - The URN of the desired fixture
+     * @param fixtureType - The typing of the desired fixture
+     * @param azMbps - The requested ingress bandwidth
+     * @param zaMbps - The requested egress bandwidth
+     * @param vlanId - The assigned VLAN ID
+     * @param sched - The requested schedule
+     * @return The reserved fixture, containing all of its reserved resources
+     */
+    public ReservedVlanFixtureE createFixtureAndResources(UrnE portUrn, EthFixtureType fixtureType, Integer azMbps,
+                                                          Integer zaMbps, Integer vlanId,
+                                                          ScheduleSpecificationE sched){
+
+
+        // Create reserved resources for Fixture
+        ReservedBandwidthE rsvBw = createReservedBandwidth(portUrn, azMbps, zaMbps, sched);
+        ReservedVlanE rsvVlan = createReservedVlan(portUrn, vlanId, sched);
+        // Create Fixture
+        return createReservedFixture(portUrn, new HashSet<>(), rsvVlan, rsvBw, fixtureType);
+    }
+
+    /**
+     * Create a reserved junction given the input
+     * @param urn - The junction's URN
+     * @param pssResources - The junction's PSS Resources
+     * @param fixtures - The junction's fixtures
+     * @param junctionType - The junction's type
+     * @return The Reserved VLAN Junction
+     */
+    public ReservedVlanJunctionE createReservedJunction(UrnE urn, Set<ReservedPssResourceE> pssResources,
+                                                        Set<ReservedVlanFixtureE> fixtures, EthJunctionType junctionType){
+        return ReservedVlanJunctionE.builder()
+                .deviceUrn(urn)
+                .reservedPssResources(pssResources)
+                .fixtures(fixtures)
+                .junctionType(junctionType)
+                .build();
+    }
+
+    /**
+     * Create a reserved fixture, given the input parameters.
+     * @param urn - The fixture's URN
+     * @param pssResources - The fixture's PSS Resources
+     * @param rsvVlan - The fixture's assigned VLAN ID
+     * @param rsvBw - The fixture's assigned bandwidth
+     * @param fixtureType - The fixture's type
+     * @return The Reserved VLAN Fixture
+     */
+    public ReservedVlanFixtureE createReservedFixture(UrnE urn, Set<ReservedPssResourceE> pssResources,
+                                                      ReservedVlanE rsvVlan, ReservedBandwidthE rsvBw,
+                                                      EthFixtureType fixtureType){
+        return ReservedVlanFixtureE.builder()
+                .ifceUrn(urn)
+                .reservedPssResources(pssResources)
+                .reservedVlan(rsvVlan)
+                .reservedBandwidth(rsvBw)
+                .fixtureType(fixtureType)
+                .build();
+    }
+
+
+    /**
+     * Create the reserved bandwidth given the input parameters.
+     * @param urn - The URN associated with this bandwidth
+     * @param inMbps - The ingress bandwidth
+     * @param egMbps - The egress bandwidth
+     * @param sched - The requested schedule
+     * @return A reserved bandwidth object
+     */
+    public ReservedBandwidthE createReservedBandwidth(UrnE urn, Integer inMbps, Integer egMbps, ScheduleSpecificationE sched){
+        return ReservedBandwidthE.builder()
+                .urn(urn)
+                .inBandwidth(inMbps)
+                .egBandwidth(egMbps)
+                .beginning(sched.getNotBefore().toInstant())
+                .ending(sched.getNotAfter().toInstant())
+                .build();
+    }
+
+    /**
+     * Create the reserved VLAN ID given the input parameters.
+     * @param urn - The URN associated with this VLAN
+     * @param vlanId - The ID value for the VLAN tag
+     * @param sched - The requested schedule
+     * @return The reserved VLAN objct
+     */
+    public ReservedVlanE createReservedVlan(UrnE urn, Integer vlanId, ScheduleSpecificationE sched){
+        return ReservedVlanE.builder()
+                .urn(urn)
+                .vlan(vlanId)
+                .beginning(sched.getNotBefore().toInstant())
+                .ending(sched.getNotAfter().toInstant())
+                .build();
+    }
+
 }

--- a/core/src/main/java/net/es/oscars/pss/PCEAssistant.java
+++ b/core/src/main/java/net/es/oscars/pss/PCEAssistant.java
@@ -93,137 +93,115 @@ public class PCEAssistant {
 
 
     /**
-     * Create a Junction and it's associated fixtures given the input parameters.
-     * @param device - The device vertex associated with the junction
-     * @param urnMap - A mapping of URN strings to URN objects
-     * @param deviceModels - A mapping of URN strings to Device Models
-     * @param requestedJunctions - A set of requested junctions - used to determine attributes of junction/fixtures
-     * @param vlanMap - Map of assigned VLANs for each fixture
-     * @param sched - The requested schedule
-     * @return A Reserved Vlan Junction with Reserved Fixtures (if contained in a matching requested junction)
-     * @throws PSSException
+     * Confirm that the two EROs are identical
+     * @param azERO - A path in one direction
+     * @param zaERO - A path in another direction
+     * @return True if they are identical, False otherwise.
      */
-    public ReservedVlanJunctionE createJunctionAndFixtures(TopoVertex device, Map<String, UrnE> urnMap,
-                                                            Map<String, DeviceModel> deviceModels,
-                                                           Set<RequestedVlanJunctionE> requestedJunctions,
-                                                           Map<UrnE, Integer> vlanMap, ScheduleSpecificationE sched)
-            throws PSSException {
-        // Get this junction's URN, Device Model, and Typing for its Fixtures
-        UrnE aUrn = urnMap.get(device.getUrn());
-        DeviceModel model = deviceModels.get(aUrn.getUrn());
-        EthFixtureType fixType = decideFixtureType(model);
+    public boolean palindromicEros(List<TopoEdge> azERO, List<TopoEdge> zaERO)
+    {
+        Set<TopoVertex> azVertices = new HashSet<>();
+        Set<TopoVertex> zaVertices = new HashSet<>();
 
-        // Create the set of Reserved Fixtures by filtering for requested junctions that match the URN
-        log.info(requestedJunctions.stream().filter(reqJunction -> reqJunction.getDeviceUrn().equals(aUrn)).collect(Collectors.toList()).toString());
-        Set<ReservedVlanFixtureE> reservedVlanFixtures = requestedJunctions
+        for(TopoEdge azEdge : azERO)
+        {
+            azVertices.add(azEdge.getA());
+            azVertices.add(azEdge.getZ());
+        }
+
+        for(TopoEdge zaEdge : zaERO)
+        {
+            zaVertices.add(zaEdge.getA());
+            zaVertices.add(zaEdge.getZ());
+        }
+
+        if(azVertices.size() != zaVertices.size())
+            return false;
+
+        for(TopoVertex oneVert : azVertices)
+        {
+            if(!zaVertices.contains(oneVert))
+                return false;
+        }
+
+        Set<TopoVertex> azPorts = azVertices
                 .stream()
-                .filter(reqJunction -> reqJunction.getDeviceUrn().equals(aUrn))
-                .map(RequestedVlanJunctionE::getFixtures)
-                .flatMap(Collection::stream)
-                .map(reqFix -> createFixtureAndResources(reqFix.getPortUrn(), fixType,
-                        reqFix.getInMbps(), reqFix.getEgMbps(), vlanMap.get(reqFix.getPortUrn()), sched))
+                .filter(v -> v.getVertexType().equals(VertexType.PORT))
+                .collect(Collectors.toSet());
+        Set<TopoVertex> zaPorts = zaVertices
+                .stream()
+                .filter(v -> v.getVertexType().equals(VertexType.PORT))
                 .collect(Collectors.toSet());
 
-        log.info("Reserved Fixtures at " + aUrn + ": " + reservedVlanFixtures);
-        // Return the Reserved Junction (with the set of reserved VLAN fixtures).
-        return createReservedJunction(aUrn, new HashSet<>(),
-                reservedVlanFixtures, decideJunctionType(model));
-    }
+        if(azPorts.size() != zaPorts.size())
+            return false;
 
-    /**
-     * Create a Reserved Fixtures and it's associated resources (VLAN and Bandwidth) using the input.
-     * @param portUrn - The URN of the desired fixture
-     * @param fixtureType - The typing of the desired fixture
-     * @param azMbps - The requested ingress bandwidth
-     * @param zaMbps - The requested egress bandwidth
-     * @param vlanId - The assigned VLAN ID
-     * @param sched - The requested schedule
-     * @return The reserved fixture, containing all of its reserved resources
-     */
-    public ReservedVlanFixtureE createFixtureAndResources(UrnE portUrn, EthFixtureType fixtureType, Integer azMbps,
-                                                           Integer zaMbps, Integer vlanId,
-                                                           ScheduleSpecificationE sched){
+        // Now see if all ports are traversed in both the ingress and egress directions
+        Set<TopoVertex> ingressPorts = new HashSet<>();
+        Set<TopoVertex> egressPorts = new HashSet<>();
 
+        // Identify which ports are used as ingress vs the ones that are used as egress
+        for(TopoEdge azEdge : azERO)
+        {
+            TopoVertex nodeA = azEdge.getA();
+            TopoVertex nodeZ = azEdge.getZ();
 
-        // Create reserved resources for Fixture
-        ReservedBandwidthE rsvBw = createReservedBandwidth(portUrn, azMbps, zaMbps, sched);
-        ReservedVlanE rsvVlan = createReservedVlan(portUrn, vlanId, sched);
-        // Create Fixture
-        return createReservedFixture(portUrn, new HashSet<>(), rsvVlan, rsvBw, fixtureType);
-    }
+            // Case 1: portA -> portZ -- portA = egress, portZ = ingress
+            if(nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
+            {
+                egressPorts.add(nodeA);
+                ingressPorts.add(nodeZ);
+            }
+            // Case 2: portA -> deviceZ -- portA = ingress
+            else if(nodeA.getVertexType().equals(VertexType.PORT) && !nodeZ.getVertexType().equals(VertexType.PORT))
+            {
+                ingressPorts.add(nodeA);
+            }
+            // Case 3: deviceA -> portZ -- portZ = egress
+            else if(!nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
+            {
+                egressPorts.add(nodeZ);
+            }
+        }
 
-    /**
-     * Create a reserved junction given the input
-     * @param urn - The junction's URN
-     * @param pssResources - The junction's PSS Resources
-     * @param fixtures - The junction's fixtures
-     * @param junctionType - The junction's type
-     * @return The Reserved VLAN Junction
-     */
-    public ReservedVlanJunctionE createReservedJunction(UrnE urn, Set<ReservedPssResourceE> pssResources,
-                                                         Set<ReservedVlanFixtureE> fixtures, EthJunctionType junctionType){
-        return ReservedVlanJunctionE.builder()
-                .deviceUrn(urn)
-                .reservedPssResources(pssResources)
-                .fixtures(fixtures)
-                .junctionType(junctionType)
-                .build();
-    }
+        // repeat above for Z->A
+        for(TopoEdge zaEdge : zaERO)
+        {
+            TopoVertex nodeA = zaEdge.getA();
+            TopoVertex nodeZ = zaEdge.getZ();
 
-    /**
-     * Create a reserved fixture, given the input parameters.
-     * @param urn - The fixture's URN
-     * @param pssResources - The fixture's PSS Resources
-     * @param rsvVlan - The fixture's assigned VLAN ID
-     * @param rsvBw - The fixture's assigned bandwidth
-     * @param fixtureType - The fixture's type
-     * @return The Reserved VLAN Fixture
-     */
-    public ReservedVlanFixtureE createReservedFixture(UrnE urn, Set<ReservedPssResourceE> pssResources,
-                                                       ReservedVlanE rsvVlan, ReservedBandwidthE rsvBw,
-                                                       EthFixtureType fixtureType){
-        return ReservedVlanFixtureE.builder()
-                .ifceUrn(urn)
-                .reservedPssResources(pssResources)
-                .reservedVlan(rsvVlan)
-                .reservedBandwidth(rsvBw)
-                .fixtureType(fixtureType)
-                .build();
-    }
+            // Case 1: portA -> portZ -- portA = egress, portZ = ingress
+            if(nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
+            {
+                egressPorts.add(nodeA);
+                ingressPorts.add(nodeZ);
+            }
+            // Case 2: portA -> deviceZ -- portA = ingress
+            else if(nodeA.getVertexType().equals(VertexType.PORT) && !nodeZ.getVertexType().equals(VertexType.PORT))
+            {
+                ingressPorts.add(nodeA);
+            }
+            // Case 3: deviceA -> portZ -- portZ = egress
+            else if(!nodeA.getVertexType().equals(VertexType.PORT) && nodeZ.getVertexType().equals(VertexType.PORT))
+            {
+                egressPorts.add(nodeZ);
+            }
+        }
 
+        // Now check to see if all ports used are both ingress and egress -- if so, palindromic port usage!
+        if(ingressPorts.size() != egressPorts.size())
+            return false;
 
-    /**
-     * Create the reserved bandwidth given the input parameters.
-     * @param urn - The URN associated with this bandwidth
-     * @param inMbps - The ingress bandwidth
-     * @param egMbps - The egress bandwidth
-     * @param sched - The requested schedule
-     * @return A reserved bandwidth object
-     */
-    public ReservedBandwidthE createReservedBandwidth(UrnE urn, Integer inMbps, Integer egMbps, ScheduleSpecificationE sched){
-        return ReservedBandwidthE.builder()
-                .urn(urn)
-                .inBandwidth(inMbps)
-                .egBandwidth(egMbps)
-                .beginning(sched.getNotBefore().toInstant())
-                .ending(sched.getNotAfter().toInstant())
-                .build();
-    }
+        if(ingressPorts.size() != azPorts.size())
+            return false;
 
-    /**
-     * Create the reserved VLAN ID given the input parameters.
-     * @param urn - The URN associated with this VLAN
-     * @param vlanId - The ID value for the VLAN tag
-     * @param sched - The requested schedule
-     * @return The reserved VLAN objct
-     */
-    public ReservedVlanE createReservedVlan(UrnE urn, Integer vlanId, ScheduleSpecificationE sched){
-        return ReservedVlanE.builder()
-                .urn(urn)
-                .vlan(vlanId)
-                .beginning(sched.getNotBefore().toInstant())
-                .ending(sched.getNotAfter().toInstant())
-                .build();
+        for(TopoVertex onePort : azPorts)
+        {
+            if(!(zaPorts.contains(onePort) && ingressPorts.contains(onePort) && egressPorts.contains(onePort)))
+                return false;
+        }
+
+        return true;
     }
 
     // TODO: fix this
@@ -593,74 +571,5 @@ public class PCEAssistant {
     }
 
 
-    /**
-     * Given two lists of EROS in the AZ and ZA direction, a map of URNs, a map of the requested bandwidth at each URN,
-     * and the requested schedule, return a combined set of reserved bandwidth objects for the AZ and ZA paths
-     * @param az - The AZ vertices
-     * @param za - The ZA vertices
-     * @param urnMap - A mapping of URN string to URN object
-     * @param requestedBandwidthMap - A mapping of Vertex objects to "Ingress"/"Egress" requested bandwidth
-     * @param sched - THe requested schedule
-     * @return A set of all reserved bandwidth for every port (across both paths)
-     */
-    public Set<ReservedBandwidthE> createReservedBandwidthForEROs(List<TopoVertex> az, List<TopoVertex> za,
-                                                                  Map<String, UrnE> urnMap,
-                                                                  Map<TopoVertex, Map<String, Integer>> requestedBandwidthMap,
-                                                                  ScheduleSpecificationE sched) {
-        // Combine the AZ and ZA EROs
-        Set<TopoVertex> combined = new HashSet<>(az);
-        combined.addAll(za);
 
-        // Store the reserved bandwidths
-        Set<ReservedBandwidthE> reservedBandwidths = new HashSet<>();
-
-        // For each vertex in the combined set, retrieve the requested Ingress/Egress bandwidth, and create a reserved
-        // bandwidth object
-        combined.stream().filter(requestedBandwidthMap::containsKey).forEach(vertex -> {
-            UrnE urn = urnMap.get(vertex.getUrn());
-            Integer reqInMbps = requestedBandwidthMap.get(vertex).get("Ingress");
-            Integer reqEgMbps = requestedBandwidthMap.get(vertex).get("Egress");
-
-            ReservedBandwidthE rsvBw = createReservedBandwidth(urn, reqInMbps, reqEgMbps, sched);
-            reservedBandwidths.add(rsvBw);
-
-        });
-
-        // Return the set
-        return reservedBandwidths;
-    }
-
-    /**
-     * Given two lists of EROS in the AZ and ZA direction, a map of URNs, a chosen vlan ID,
-     * and the requested schedule, return a combined set of reserved VLAN objects for the AZ and ZA paths
-     * @param az - The AZ vertices
-     * @param za - The ZA vertices
-     * @param urnMap - A mapping of URN string to URN object
-     * @param vlanMap - A mapping of URN object to assigned VLAN ID
-     * @param sched - THe requested schedule
-     * @return A set of all reserved VLAN objects for every port (across both paths)
-     */
-    public Set<ReservedVlanE> createReservedVlanForEROs(List<TopoVertex> az, List<TopoVertex> za,
-                                                        Map<String, UrnE> urnMap, Map<UrnE, Integer> vlanMap,
-                                                        ScheduleSpecificationE sched) {
-        // Combine the AZ and ZA EROs
-        Set<TopoVertex> combined = new HashSet<>(az);
-        combined.addAll(za);
-
-        // Store the reserved bandwidths
-        Set<ReservedVlanE> reservedVlans = new HashSet<>();
-
-        // For each vertex in the combined set, retrieve the requested Ingress/Egress bandwidth, and create a reserved
-        // bandwidth object
-        combined.stream().filter(vertex -> vertex.getVertexType().equals(VertexType.PORT)).forEach(vertex -> {
-            UrnE urn = urnMap.get(vertex.getUrn());
-
-            ReservedVlanE rsvVlan = createReservedVlan(urn, vlanMap.get(urn), sched);
-            reservedVlans.add(rsvVlan);
-
-        });
-
-        // Return the set
-        return reservedVlans;
-    }
 }


### PR DESCRIPTION
## Minor Change
1. **Migrate Bandwidth and VLAN Methods** - Various methods in TranslationPCE, PruningService, and PCEAssistant have been moved into the VlanService and BandwidthService classes to logically consolidate them. This also causes a change in TopPCE, which now calls the VlanService and BandwidthService, rather than TranslationPCE, for retrieving reserved Bandwidth/VLANs. 
