### PR TITLE
Towards #91 (Make OSCARS poll for new / updated topology files).

### DIFF
--- a/core/config/application.properties
+++ b/core/config/application.properties
@@ -35,6 +35,9 @@ rest.internal-truststore-path=${startup.defaults.ssl_key_store}
 proc.timeout-held-after=300
 
 topo.prefix=esnet
+topo.import-script-path=../topo/esdb_topo.py
+# Uncomment and replace xxx with an actual ESDB API key
+# topo.esdb-key=xxx
 
 pss.vcid-range=7000:7999
 pss.alu-svcid-range=7000:7999

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -83,6 +83,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.zeroturnaround</groupId>
+            <artifactId>zt-exec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <exclusions>

--- a/core/src/main/java/net/es/oscars/topo/prop/TopoProperties.java
+++ b/core/src/main/java/net/es/oscars/topo/prop/TopoProperties.java
@@ -13,4 +13,6 @@ import org.springframework.context.annotation.Configuration;
 public class TopoProperties {
     @NonNull
     private String prefix;
+    private String esdbKey;
+    private String importScriptPath;
 }


### PR DESCRIPTION
Periodically (every hour) do a call to ESDB to grab the current "today" topology.  This requires a valid ESDB API key in the topo.esdb-key property.

Note that all this change does is update files.  It doesn't force OSCARS to process the updated topology, or make changes to its internal topology model.  That functionality is slated for issue #92.