### PR TITLE
Factor out some property definitions for RPM building

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>backend</artifactId>
     <properties>
         <cucumber.options>--tags @unit --strict</cucumber.options>
+	<rpm.home>/usr/local/esnet/oscars-backend</rpm.home>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,6 @@
 	<rpm.organization.name>ESnet</rpm.organization.name>
 	<rpm.organization.url>https://www.github.com/esnet/oscars-newtech</rpm.organization.url>
 	<rpm.license>BSD</rpm.license>
-	<rpm.home>/usr/local/esnet/oscars-backend</rpm.home>
     </properties>
 
     <pluginRepositories>

--- a/pss/pom.xml
+++ b/pss/pom.xml
@@ -10,6 +10,7 @@
     </parent>
     <properties>
         <cucumber.options>--tags @unit --strict</cucumber.options>
+	<rpm.home>/usr/local/esnet/oscars-pss</rpm.home>
     </properties>
 
 


### PR DESCRIPTION
Move common property definitions in subprojects into the top-level pom.xml file.
