### PR TITLE
Include install_db.sh in the oscars-backend RPM.

### DIFF
--- a/backend/bin/install_db.sh
+++ b/backend/bin/install_db.sh
@@ -51,11 +51,6 @@ echo "Configured Postgres. Please, edit backend/config/application.properties an
 echo "the password in the 'spring.datasource.password' line, if you haven't already."
 read -p " Press enter to create OSCARS tables.. "
 
-
-cd backend
-
-java -jar target/backend-1.0.0-beta.jar \
+java -jar lib/backend.jar \
     --spring.jpa.hibernate.ddl-auto=update \
     --startup.exit=true spring.datasource.password=${password}
-
-cd ..

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -287,6 +287,14 @@
                     </defineStatements>
                     <mappings>
                         <mapping>
+                            <directory>${rpm.home}/bin</directory>
+                            <sources>
+                                <source>
+                                    <location>${project.basedir}/bin/install_db.sh</location>
+                                </source>
+                            </sources>
+                        </mapping>
+                        <mapping>
                             <directory>${rpm.home}/lib</directory>
                             <sources>
                                 <source>


### PR DESCRIPTION
Also moves install_db to a more appropriate location in the source
tree.  It's intended that this be run from its installed location,
in other words not within the source tree.

Fixes #132.