### PR TITLE
Fix for services going to failed state after being stopped.

### DIFF
--- a/backend/oscars-backend.service
+++ b/backend/oscars-backend.service
@@ -10,6 +10,7 @@ Group=nobody
 WorkingDirectory=/usr/local/esnet/oscars-backend
 ExecStart=/usr/bin/java -jar /usr/local/esnet/oscars-backend/lib/backend.jar
 KillMode=process
+SuccessExitStatus=143
 
 [Install]
 WantedBy=multi-user.target

--- a/pss/oscars-pss.service
+++ b/pss/oscars-pss.service
@@ -10,6 +10,7 @@ Group=nobody
 WorkingDirectory=/usr/local/esnet/oscars-pss
 ExecStart=/usr/bin/java -jar /usr/local/esnet/oscars-pss/lib/pss.jar
 KillMode=process
+SuccessExitStatus=143
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Inspired by:

https://serverfault.com/questions/695849/services-remain-in-failed-state-after-stopped-with-systemctl

Fixes #137.