### PR TITLE
Update nsi-peerings.json to reflect configuration of oscars-web.es.net.

### DIFF
--- a/backend/config/nsi-peerings.json
+++ b/backend/config/nsi-peerings.json
@@ -12,13 +12,13 @@
     "vlan": "6-4094"
   },
   {
-    "out": {
-      "local": "star-cr5:6_1_1:star-tb1:out",
-      "remote": "urn:ogf:network:tb.es.net:2013::star-tb1:1_1_1:+:out"
-    },
     "in": {
       "local": "star-cr5:6_1_1:star-tb1:in",
       "remote": "urn:ogf:network:tb.es.net:2013::star-tb1:1_1_1:+:out"
+    },
+    "out": {
+      "local": "star-cr5:6_1_1:star-tb1:out",
+      "remote": "urn:ogf:network:tb.es.net:2013::star-tb1:1_1_1:+:in"
     },
     "capacity": "100G",
     "vlan": "6-4094"
@@ -34,7 +34,7 @@
       "remote": "urn:ogf:network:snvaca.pacificwave.net:2016:topology:esnet-sunnyvale-in"
     },
     "capacity": "50G",
-    "vlan": "1779-1799"
+    "vlan": "1070-1079,1779-1799"
   },
   {
     "in": {
@@ -51,11 +51,11 @@
   {
     "in": {
       "local": "chic-cr5:5_1_1:al2s:in",
-      "remote": "urn:ogf:network:al2s.net.internet2.edu:2013::rtsw.chic.net.internet2.edu:et-4_3_0.0:esnet:out"
+      "remote": "urn:ogf:network:al2s.net.internet2.edu:2013::rtsw.chic.net.internet2.edu:et-4/3/0:esnet:out"
     },
     "out": {
       "local": "chic-cr5:5_1_1:al2s:out",
-      "remote": "urn:ogf:network:al2s.net.internet2.edu:2013::rtsw.chic.net.internet2.edu:et-4_3_0.0:esnet:in"
+      "remote": "urn:ogf:network:al2s.net.internet2.edu:2013::rtsw.chic.net.internet2.edu:et-4/3/0:esnet:in"
     },
     "capacity": "80G",
     "vlan": "2-4089"
@@ -64,11 +64,11 @@
   {
     "in": {
       "local": "sunn-cr5:7_2_1:al2s:in",
-      "remote": "urn:ogf:network:al2s.net.internet2.edu:2013::sdn-sw.sunn.net.internet2.edu:et-7_0_0.0:esnet-sunn:out"
+      "remote": "urn:ogf:network:al2s.net.internet2.edu:2013::sdn-sw.sunn.net.internet2.edu:et-7/0/0:esnet-sunn:out"
     },
     "out": {
       "local": "sunn-cr5:7_2_1:al2s:out",
-      "remote": "urn:ogf:network:al2s.net.internet2.edu:2013::sdn-sw.sunn.net.internet2.edu:et-7_0_0.0:esnet-sunn:in"
+      "remote": "urn:ogf:network:al2s.net.internet2.edu:2013::sdn-sw.sunn.net.internet2.edu:et-7/0/0:esnet-sunn:in"
     },
     "capacity": "80G",
     "vlan": "2-4089"
@@ -111,23 +111,23 @@
   },
   {
     "in": {
-      "local": "amst-cr5:3_1_1:+:out",
-      "remote": "urn:ogf:network:netherlight.net:2013:production7:esnet-1-in"
-    },
-    "out": {
       "local": "amst-cr5:3_1_1:+:in",
       "remote": "urn:ogf:network:netherlight.net:2013:production7:esnet-1-out"
+    },
+    "out": {
+      "local": "amst-cr5:3_1_1:+:out",
+      "remote": "urn:ogf:network:netherlight.net:2013:production7:esnet-1-in"
     },
     "capacity": "10G",
     "vlan": "1000-1019"
   },
   {
     "in": {
-      "local": "star-cr5:10_1_8:+:out",
+      "local": "star-cr5:10_1_8:+:in",
       "remote": "urn:ogf:network:icair.org:2013:topology:esnet-in"
     },
     "out": {
-      "local": "star-cr5:10_1_8:+:in",
+      "local": "star-cr5:10_1_8:+:out",
       "remote": "urn:ogf:network:icair.org:2013:topology:esnet-out"
     },
     "capacity": "10G",


### PR DESCRIPTION
This fixes a few naming problems, including with AL2S.