### PR TITLE
feat: [OS-17] Add and track last-modified timestamp per connection

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -3,6 +3,16 @@ This file contains instructions for updating an existing installation of OSCARS 
 
 Instructions include config file changes, database schema changes, etc.
 
+## 1.0.32 to 1.0.33
+
+### Database schema changes:
+
+- In the `oscars_backend` database:
+
+```
+alter table connection add column last_modified int;
+update connection set last_modified = 0;
+```
 
 ## 1.0.26 to 1.0.32
 

--- a/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
+++ b/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
@@ -10,6 +10,7 @@ import net.es.oscars.resv.enums.Phase;
 import net.es.oscars.resv.enums.State;
 
 import javax.persistence.*;
+import java.time.Instant;
 import java.util.List;
 
 @Data

--- a/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
+++ b/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
@@ -29,7 +29,8 @@ public class Connection {
                       @JsonProperty("tags") List<Tag> tags,
                       @JsonProperty("held") Held held,
                       @JsonProperty("archived") Archived archived,
-                      @JsonProperty("connection_mtu") Integer connection_mtu) {
+                      @JsonProperty("connection_mtu") Integer connection_mtu,
+                      @JsonProperty("last_modified") Integer last_modified) {
         this.connectionId = connectionId;
         this.phase = phase;
         this.mode = mode;
@@ -41,6 +42,7 @@ public class Connection {
         this.held = held;
         this.archived = archived;
         this.connection_mtu = connection_mtu;
+        this.last_modified = last_modified;
     }
 
 
@@ -86,4 +88,7 @@ public class Connection {
 
     @NonNull
     private Integer connection_mtu;
+
+    @NonNull
+    private Integer last_modified;
 }

--- a/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
@@ -85,7 +85,6 @@ public class ConnService {
     @Autowired
     private TopoService topoService;
 
-
     @Value("${pss.default-mtu:9000}")
     private Integer defaultMtu;
 
@@ -97,6 +96,8 @@ public class ConnService {
 
     @Value("${resv.minimum-duration:15}")
     private Integer minDuration;
+
+    private Integer lastModified;
 
     public String generateConnectionId() {
         boolean found = false;

--- a/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
@@ -97,8 +97,6 @@ public class ConnService {
     @Value("${resv.minimum-duration:15}")
     private Integer minDuration;
 
-    private Integer lastModified;
-
     public String generateConnectionId() {
         boolean found = false;
         String result = "";
@@ -382,6 +380,9 @@ public class ConnService {
             c.setHeld(null);
             connRepo.saveAndFlush(c);
 
+            Instant instant = Instant.now();
+            c.setLast_modified((int)instant.getEpochSecond());
+
         } finally {
             // log.debug("unlocked connections");
             connLock.unlock();
@@ -410,6 +411,7 @@ public class ConnService {
         c.setReserved(null);
         c.setHeld(h);
         connRepo.saveAndFlush(c);
+
         return ConnChangeResult.builder()
                 .what(ConnChange.UNCOMMITTED)
                 .phase(Phase.HELD)
@@ -516,6 +518,10 @@ public class ConnService {
             c.setPhase(Phase.ARCHIVED);
             c.setHeld(null);
             c.setReserved(null);
+
+            Instant instant = Instant.now();
+            c.setLast_modified((int)instant.getEpochSecond());
+
             connRepo.saveAndFlush(c);
 
         } finally {
@@ -1185,6 +1191,7 @@ public class ConnService {
                 .phase(Phase.HELD)
                 .description("")
                 .username("")
+                .last_modified((int)Instant.now().getEpochSecond())
                 .connectionId(in.getConnectionId())
                 .state(State.WAITING)
                 .connection_mtu(in.getConnection_mtu())

--- a/backend/src/main/java/net/es/oscars/web/rest/PssController.java
+++ b/backend/src/main/java/net/es/oscars/web/rest/PssController.java
@@ -142,6 +142,10 @@ public class PssController {
 
             try {
                 c.setState(pssAdapter.build(c));
+
+                Instant instant = Instant.now();
+                c.setLast_modified((int)instant.getEpochSecond());
+
             } catch (PSSException ex) {
                 c.setState(State.FAILED);
                 log.error(ex.getMessage(), ex);
@@ -174,6 +178,10 @@ public class PssController {
 
             try {
                 c.setState(pssAdapter.dismantle(c));
+
+                Instant instant = Instant.now();
+                c.setLast_modified((int)instant.getEpochSecond());
+
             } catch (PSSException ex) {
                 c.setState(State.FAILED);
                 log.error(ex.getMessage(), ex);

--- a/backend/src/main/java/net/es/oscars/web/simple/SimpleConnection.java
+++ b/backend/src/main/java/net/es/oscars/web/simple/SimpleConnection.java
@@ -21,6 +21,7 @@ public class SimpleConnection {
     protected Integer begin;
     protected Integer end;
     protected Integer connection_mtu;
+    protected Integer last_modified;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     protected Integer heldUntil;
     protected String username;

--- a/frontend/src/main/js/components/connectionsList.js
+++ b/frontend/src/main/js/components/connectionsList.js
@@ -130,7 +130,7 @@ class ConnectionsList extends Component {
         // Setting the sizePerPage to -1 returns us the entire connection list
         filter.page = csFilter.page;
         filter.sizePerPage = -1;
-        filter.phase = csFilter.phase;
+        filter.phase = "ANY";
 
         myClient.submit("POST", "/api/conn/list", filter).then(
             successResponse => {
@@ -234,7 +234,7 @@ class ConnectionsList extends Component {
                 <select
                     onChange={event => onChange(event.target.value)}
                     style={{ width: "100%" }}
-                    value={filter ? filter.value : "reserved"}
+                    value={filter ? filter.value : "any"}
                 >
                     <option value="any">Any</option>
                     <option value="reserved">Reserved</option>


### PR DESCRIPTION
### Description

This PR adds a new field `last_modifed` that can track the last-modified timestamp per connection. Also, there's a minor fix for fetching all the connections in the connections list page
 
### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [x] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
