### PR TITLE
fix: [OS-49] automate version consistency

### DIFF
--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+mvn -N versions:update-child-modules

--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
 mvn -N versions:update-child-modules
+git add

--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 mvn -N versions:update-child-modules
-git add
+git add '*/pom.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -281,10 +281,7 @@
                         </goals>
                         <configuration>
                             <hooks>
-                                <pre-commit>
-                                    echo updating version numbers
-                                    exec mvn -N versions:update-child-modules
-                                </pre-commit>
+                                <pre-commit>exec git-hooks/pre-commit.sh</pre-commit>
                             </hooks>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,27 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce-same-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <reactorModuleConvergence>
+                                    <message>The reactor is not valid</message>
+                                </reactorModuleConvergence>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>io.github.phillipuniverse</groupId>
                 <artifactId>githook-maven-plugin</artifactId>
                 <version>1.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
+            <dependency>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <type>maven-plugin</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>
@@ -264,6 +269,28 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>io.github.phillipuniverse</groupId>
+                <artifactId>githook-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>install</goal>
+                        </goals>
+                        <configuration>
+                            <hooks>
+                                <pre-commit>
+                                    echo updating version numbers
+                                    exec mvn -N versions:update-child-modules
+                                </pre-commit>
+                            </hooks>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/pss/pom.xml
+++ b/pss/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>oscars</artifactId>
         <groupId>net.es.oscars</groupId>
-        <version>1.0.32</version>
+        <version>1.0.33</version>
     </parent>
 
     <organization>


### PR DESCRIPTION
### Description
This automates checking and updating maven versions between the top-level pom.xml and the various submodules. This works as follows:

- the  maven enforcer plugin is configured to fail the build from the top level if it detects that the parent is not set consistently in the child submodules. 
- if we ignore that and do a commit anyway, there is a git hook (installed via a maven plugin) that will update the child pom.xml files to match the parent using the maven version plugin, and add the updated files to the commit.

This should mitigate most of the version mismatch issues. 

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [x] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.