### PR TITLE
fix: [OS-50] Fix reservation list UI performance issues

### DIFF
--- a/frontend/src/main/js/components/connectionsList.js
+++ b/frontend/src/main/js/components/connectionsList.js
@@ -144,15 +144,17 @@ class ConnectionsList extends Component {
     filterData = (filter, filtered) => {
         if (filtered.length > 0) {
             for (let key in filtered) {
-                let item = filtered[key];
-                if (item["id"] === "ports") {
-                    filter[item["id"]] = [item["value"]];
-                } else if (item["id"] === "fixtures") {
-                    filter["vlans"] = [item["value"]];
-                } else if (item["id"] === "phase") {
-                    filter[item["id"]] = item["value"].toLocaleUpperCase();
+                let itemKey = filtered[key]["id"];
+                let itemValue = filtered[key]["value"];
+
+                if (itemKey === "ports") {
+                    filter[itemKey] = [itemValue];
+                } else if (itemKey === "fixtures") {
+                    filter["vlans"] = [itemValue];
+                } else if (itemKey === "phase") {
+                    filter[itemKey] = itemValue.toLocaleUpperCase();
                 } else {
-                    filter[item["id"]] = item["value"];
+                    filter[itemKey] = itemValue;
                 }
             }
         }

--- a/frontend/src/main/js/components/connectionsList.js
+++ b/frontend/src/main/js/components/connectionsList.js
@@ -142,16 +142,18 @@ class ConnectionsList extends Component {
     };
 
     filterData = (filter, filtered) => {
-        for (let key in filtered) {
-            let item = filtered[key];
-            if (item["id"] === "ports") {
-                filter[item["id"]] = [item["value"]];
-            } else if (item["id"] === "fixtures") {
-                filter["vlans"] = [item["value"]];
-            } else if (item["id"] === "phase") {
-                filter[item["id"]] = item["value"].toLocaleUpperCase();
-            } else {
-                filter[item["id"]] = item["value"];
+        if (filtered.length > 0) {
+            for (let key in filtered) {
+                let item = filtered[key];
+                if (item["id"] === "ports") {
+                    filter[item["id"]] = [item["value"]];
+                } else if (item["id"] === "fixtures") {
+                    filter["vlans"] = [item["value"]];
+                } else if (item["id"] === "phase") {
+                    filter[item["id"]] = item["value"].toLocaleUpperCase();
+                } else {
+                    filter[item["id"]] = item["value"];
+                }
             }
         }
         return filter;

--- a/frontend/src/main/js/stores/connsStore.js
+++ b/frontend/src/main/js/stores/connsStore.js
@@ -128,8 +128,9 @@ class ConnectionsStore {
         phase: "RESERVED",
         state: "ACTIVE",
         sizePerPage: 5,
-        page: 1,
-        totalSize: 0
+        page: 0,
+        totalPages: 1,
+        filtered: []
     };
 
     @action setParamsForEditSchedule(params) {


### PR DESCRIPTION
### Description

Fix reservation list UI performance issues by setting react-table to handle filtering on the server side and handling fetching of data page by page instead of all at once. Also, the default phase option is changed back to RESERVED

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [x] This PR has updated documentation as appropriate
- [ ] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
