### PR TITLE
feat: [OS-146] name LSPs with serviceId

### DIFF
--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -119,6 +119,8 @@ nso.retry-attempts=5
 # when retrying, how long to wait between retries
 nso.backoff-milliseconds=30000
 
+nso.mock-live-show-commands=true
+nso.routing-domain=esnet-293
 nso.uri=${NSO_URI}
 nso.username=${NSO_USERNAME}
 nso.password=${NSO_PASSWORD}

--- a/backend/src/main/java/net/es/oscars/app/props/NsoProperties.java
+++ b/backend/src/main/java/net/es/oscars/app/props/NsoProperties.java
@@ -31,6 +31,11 @@ public class NsoProperties {
         }
     }
 
+    public boolean mockLiveShowCommands;
+
+    @NonNull
+    public String routingDomain;
+
     @NonNull
     public String username;
 

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
@@ -706,6 +706,7 @@ public class NsiService {
                     .end(end.intValue())
                     .fixtures(fixturesAndJunctions.getLeft())
                     .junctions(fixturesAndJunctions.getRight())
+                    .serviceId(null)
                     .pipes(pipes)
                     .tags(tags)
                     .username("nsi")

--- a/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
+++ b/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
@@ -26,12 +26,13 @@ public class Connection {
                       @JsonProperty("deployment-intent") @NonNull DeploymentIntent deploymentIntent,
                       @JsonProperty("username") @NonNull String username,
                       @JsonProperty("description") @NonNull String description,
+                      @JsonProperty("service-id") String serviceId,
                       @JsonProperty("reserved") Reserved reserved,
                       @JsonProperty("tags") List<Tag> tags,
                       @JsonProperty("held") Held held,
                       @JsonProperty("archived") Archived archived,
-                      @JsonProperty("connection_mtu") Integer connection_mtu,
-                      @JsonProperty("last_modified") Integer last_modified) {
+                      @JsonProperty("connection_mtu") @NonNull Integer connection_mtu,
+                      @JsonProperty("last_modified") @NonNull Integer last_modified) {
         this.connectionId = connectionId;
         this.phase = phase;
         this.mode = mode;
@@ -40,6 +41,7 @@ public class Connection {
         this.deploymentIntent = deploymentIntent;
         this.username = username;
         this.description = description;
+        this.serviceId = serviceId;
         this.reserved = reserved;
         this.tags = tags;
         this.held = held;
@@ -78,6 +80,9 @@ public class Connection {
 
     @NonNull
     private String username;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String serviceId;
 
     @OneToMany(cascade = CascadeType.ALL)
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/backend/src/main/java/net/es/oscars/resv/svc/ConnUtils.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ConnUtils.java
@@ -6,7 +6,6 @@ import net.es.oscars.resv.ent.*;
 import net.es.oscars.resv.enums.Phase;
 import net.es.oscars.resv.enums.State;
 import net.es.oscars.sb.nso.db.NsoVcIdDAO;
-import net.es.oscars.topo.enums.CommandParamType;
 import net.es.oscars.web.simple.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -17,7 +16,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.IntStream;
 
@@ -82,22 +80,7 @@ public class ConnUtils {
         c.setReserved(reserved);
     }
 
-    public static Held heldFromReserved(Connection c) {
 
-        Components cmp = c.getReserved().getCmp();
-        Schedule sch = copySchedule(c.getReserved().getSchedule());
-        sch.setPhase(Phase.HELD);
-
-        Instant exp = Instant.now().plus(15L, ChronoUnit.MINUTES);
-
-        Components heldCmp = copyComponents(cmp, sch);
-        return Held.builder()
-                .cmp(heldCmp)
-                .connectionId(c.getConnectionId())
-                .schedule(sch)
-                .expiration(exp)
-                .build();
-    }
 
     public static void archiveFromReserved(Connection c) {
         Components cmp = c.getReserved().getCmp();
@@ -228,6 +211,7 @@ public class ConnUtils {
             throw new IllegalArgumentException(c.getConnectionId() + " not in HELD phase");
         }
         c.setDescription(in.getDescription());
+        c.setServiceId(in.getServiceId());
         c.setUsername(in.getUsername());
         c.setMode(in.getMode());
 
@@ -459,6 +443,7 @@ public class ConnUtils {
                 .begin(b.intValue())
                 .end(e.intValue())
                 .connectionId(c.getConnectionId())
+                .serviceId(c.getServiceId())
                 .tags(simpleTags)
                 .description(c.getDescription())
                 .mode(c.getMode())

--- a/backend/src/main/java/net/es/oscars/resv/svc/ResvLibrary.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ResvLibrary.java
@@ -4,12 +4,9 @@ import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.resv.beans.PeriodBandwidth;
 import net.es.oscars.resv.ent.*;
 import net.es.oscars.resv.enums.BwDirection;
-import net.es.oscars.resv.enums.Phase;
 import net.es.oscars.topo.beans.IntRange;
 import net.es.oscars.topo.beans.PortBwVlan;
-import net.es.oscars.topo.beans.ReservableCommandParam;
 import net.es.oscars.topo.beans.TopoUrn;
-import net.es.oscars.topo.enums.CommandParamType;
 import net.es.oscars.topo.enums.Layer;
 import net.es.oscars.topo.enums.UrnType;
 
@@ -18,8 +15,15 @@ import java.util.*;
 
 @Slf4j
 public class ResvLibrary {
+    public static String SERVICE_ID_REGEX = "^[a-zA-Z0-9]+$";
 
-
+    public static boolean validateServiceId(String serviceId) {
+        if (serviceId == null || serviceId.isEmpty()) {
+            return true;
+        } else {
+            return serviceId.matches(SERVICE_ID_REGEX);
+        }
+    }
 
 
     public static Map<String, PortBwVlan> portBwVlans(Map<String, TopoUrn> urnMap,
@@ -61,36 +65,6 @@ public class ResvLibrary {
         return available;
     }
 
-    public static List<Schedule> schedulesOverlapping(List<Schedule> all, Instant b, Instant e) {
-        List<Schedule> overlapping = new ArrayList<>();
-        for (Schedule s : all) {
-            if (s.getPhase().equals(Phase.HELD) || s.getPhase().equals(Phase.RESERVED)) {
-                if (s.overlaps(b, e)) {
-                    overlapping.add(s);
-                }
-
-            }
-        }
-        return overlapping;
-    }
-
-    public static List<PeriodBandwidth> pbwsOverlapping(List<PeriodBandwidth> candidates, Instant b, Instant e) {
-        List<PeriodBandwidth> result = new ArrayList<>();
-        for (PeriodBandwidth pbw : candidates) {
-            log.info("evaluating a pbw: " + pbw.toString());
-            boolean add = true;
-            if (pbw.getEnding().isBefore(b) || pbw.getBeginning().isAfter(e)) {
-                add = false;
-            }
-            if (add) {
-                log.info("adding a pbw: " + pbw.toString());
-                result.add(pbw);
-            }
-        }
-
-        return result;
-    }
-
 
     public static Map<String, Integer> availableBandwidthMap(BwDirection dir, Map<String, TopoUrn> baseline,
                                                              Map<String, List<PeriodBandwidth>> reservedBandwidths) {
@@ -113,56 +87,12 @@ public class ResvLibrary {
         return result;
 
     }
-    public static Map<String, Set<ReservableCommandParam>>
-            availableCommandParams(Map<String, TopoUrn> baseline, Map<String, Set<CommandParam>> reservedParams) {
-        Map<String, Set<ReservableCommandParam>> result = new HashMap<>();
-        for (String urn: baseline.keySet()) {
-            if (!result.containsKey(urn)) {
-                result.put(urn, new HashSet<>());
-            }
-
-
-            Set<ReservableCommandParam> reservable = baseline.get(urn).getReservableCommandParams();
-            Set<CommandParam> reservedOnUrn = new HashSet<>();
-            if (reservedParams.containsKey(urn)) {
-                reservedOnUrn = reservedParams.get(urn);
-            }
-            Set<CommandParamType> cpts = new HashSet<>();
-            reservable.forEach(r -> {
-                cpts.add(r.getType());
-            });
-            for (CommandParamType cpt: cpts) {
-                Set<IntRange> reservableOfType = new HashSet<>();
-                for (ReservableCommandParam rcp : reservable) {
-                    if (rcp.getType().equals(cpt)) {
-                        reservableOfType.addAll(rcp.getReservableRanges());
-                    }
-                }
-                Set<Integer> reservedOfType = new HashSet<>();
-                for (CommandParam cp : reservedOnUrn) {
-                    if (cp.getParamType().equals(cpt)) {
-                        reservedOfType.add(cp.getResource());
-                    }
-                }
-                Set<IntRange> availableofType = availableInts(reservableOfType, reservedOfType);
-                ReservableCommandParam rcp = ReservableCommandParam.builder()
-                        .type(cpt)
-                        .reservableRanges(availableofType)
-                        .build();
-                result.get(urn).add(rcp);
-            }
-        }
-
-
-
-        return result;
-    }
 
     public static Map<String, Set<IntRange>> availableVlanMap(Map<String, TopoUrn> baseline, Collection<Vlan> reservedVlans) {
 
         Map<String, Set<Integer>> reservedVlanMap = new HashMap<>();
         reservedVlans.forEach(v -> {
-            if (!reservedVlanMap.keySet().contains(v.getUrn())) {
+            if (!reservedVlanMap.containsKey(v.getUrn())) {
                 reservedVlanMap.put(v.getUrn(), new HashSet<>());
             }
             reservedVlanMap.get(v.getUrn()).add(v.getVlanId());
@@ -192,50 +122,6 @@ public class ResvLibrary {
         return IntRange.fromSet(available);
     }
 
-    public static Map<String, TopoUrn> constructAvailabilityMap(
-            Map<String, TopoUrn> urnMap,
-            Map<String, Set<IntRange>> availVlanMap,
-            Map<String, Integer> availIngressBwMap,
-            Map<String, Integer> availEgressBwMap,
-            Map<String, Set<ReservableCommandParam>> availCommandParamMap) {
-
-        Map<String, TopoUrn> result = new HashMap<>();
-
-        for (Map.Entry<String, TopoUrn> e : urnMap.entrySet()) {
-            TopoUrn u = e.getValue();
-
-            HashSet<Layer> capabilities = new HashSet<>();
-            capabilities.addAll(u.getCapabilities());
-
-            TopoUrn copy = TopoUrn.builder()
-                    .capabilities(capabilities)
-                    .device(u.getDevice())
-                    .port(u.getPort())
-                    .reservableVlans(availVlanMap.get(u.getUrn()))
-                    .reservableEgressBw(availEgressBwMap.get(u.getUrn()))
-                    .reservableIngressBw(availIngressBwMap.get(u.getUrn()))
-                    .reservableCommandParams(availCommandParamMap.get(u.getUrn()))
-                    .build();
-
-            result.put(e.getKey(), copy);
-        }
-        return result;
-
-    }
-
-
-    public static Integer availBandwidth(Integer reservableBw,
-                                         Collection<PeriodBandwidth> periodBandwidths,
-                                         Instant when) {
-        Integer result = reservableBw;
-        for (PeriodBandwidth pbw : periodBandwidths) {
-            if (pbw.getBeginning().isBefore(when) && pbw.getEnding().isAfter(when)) {
-                result -= pbw.getBandwidth();
-            }
-        }
-
-        return result;
-    }
 
     public static Integer overallAvailBandwidth(Integer reservableBw,
                                                 Collection<PeriodBandwidth> periodBandwidths) {
@@ -271,16 +157,6 @@ public class ResvLibrary {
         return reservableBw - maxReserved;
     }
 
-    public static Integer minBwOverPath(List<TopoUrn> topoUrns, Map<String, Integer> availableBws) {
-        Integer min = Integer.MAX_VALUE;
-        for (TopoUrn topoUrn: topoUrns) {
-            Integer thisBw = availableBws.get(topoUrn.getUrn());
-            if (thisBw != null && thisBw < min) {
-                min = thisBw;
-            }
-        }
-        return min;
-    }
 
     public static Map<String, Integer> decideIdentifier(Map<String, Set<IntRange>> requested,
                                                         Map<String, Set<IntRange>> available) {

--- a/backend/src/main/java/net/es/oscars/sb/nso/NsoAdapter.java
+++ b/backend/src/main/java/net/es/oscars/sb/nso/NsoAdapter.java
@@ -1,11 +1,9 @@
 package net.es.oscars.sb.nso;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import net.es.oscars.app.props.NsoProperties;
 import net.es.oscars.sb.nso.db.NsoSdpVcIdDAO;
 import net.es.oscars.sb.nso.ent.NsoSdpVcId;
 import net.es.oscars.sb.nso.exc.NsoCommitException;
@@ -33,44 +31,55 @@ import net.es.oscars.sb.nso.rest.NsoServicesWrapper;
 import net.es.topo.common.dto.nso.NsoLSP;
 import net.es.topo.common.dto.nso.NsoVPLS;
 import net.es.topo.common.dto.nso.enums.*;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.*;
 
+import static net.es.oscars.resv.svc.ResvLibrary.validateServiceId;
 import static net.es.topo.common.devel.DevelUtils.dumpDebug;
 
 @Component
 @Slf4j
 public class NsoAdapter {
     public static String NSO_TEMPLATE_VERSION = "NSO 1.1";
+    public static String WORK_LSP_NAME_PIECE = "WRK";
+    public static String PROTECT_LSP_NAME_PIECE = "PRT";
+    public static String LSP_NAME_DELIMITER = "-";
 
-    @Autowired
-    private NsoProxy nsoProxy;
+    private final NsoProperties nsoProperties;
 
-    @Autowired
-    private NsoVcIdDAO nsoVcIdDAO;
+    private final NsoProxy nsoProxy;
 
-    @Autowired
-    private NsoQosSapPolicyIdDAO nsoQosSapPolicyIdDAO;
+    private final NsoVcIdDAO nsoVcIdDAO;
 
-    @Autowired
-    private NsoSdpIdDAO nsoSdpIdDAO;
+    private final NsoQosSapPolicyIdDAO nsoQosSapPolicyIdDAO;
 
-    @Autowired
-    private NsoSdpVcIdDAO nsoSdpVcIdDAO;
+    private final NsoSdpIdDAO nsoSdpIdDAO;
 
-    @Autowired
-    private CommandHistoryRepository historyRepo;
+    private final NsoSdpVcIdDAO nsoSdpVcIdDAO;
 
-    @Autowired
-    private RouterCommandsRepository rcr;
+    private final CommandHistoryRepository historyRepo;
 
-    @Autowired
-    private MiscHelper miscHelper;
+    private final RouterCommandsRepository rcr;
 
-    public final static String ROUTING_DOMAIN = "esnet-293"; // FIXME: this needs to come from topology, probably
+    private final MiscHelper miscHelper;
+
+    public NsoAdapter(NsoProperties nsoProperties, NsoProxy nsoProxy, MiscHelper miscHelper,
+                      NsoVcIdDAO nsoVcIdDAO, NsoQosSapPolicyIdDAO nsoQosSapPolicyIdDAO, NsoSdpIdDAO nsoSdpIdDAO,
+                      NsoSdpVcIdDAO nsoSdpVcIdDAO, CommandHistoryRepository historyRepo, RouterCommandsRepository rcr) {
+        this.nsoProperties = nsoProperties;
+        this.nsoProxy = nsoProxy;
+        this.nsoVcIdDAO = nsoVcIdDAO;
+        this.nsoQosSapPolicyIdDAO = nsoQosSapPolicyIdDAO;
+        this.nsoSdpIdDAO = nsoSdpIdDAO;
+        this.nsoSdpVcIdDAO = nsoSdpVcIdDAO;
+        this.historyRepo = historyRepo;
+        this.rcr = rcr;
+        this.miscHelper = miscHelper;
+    }
+
+
     public SouthboundTaskResult processTask(Connection conn, CommandType commandType, State intent)  {
         log.info("processing southbound NSO task "+conn.getConnectionId()+" "+commandType.toString());
 
@@ -161,13 +170,11 @@ public class NsoAdapter {
                 .commandType(commandType)
                 .build();
     }
-    public NsoLSP makeNsoLSP(String connectionId, VlanJunction thisJunction, VlanJunction otherJunction, List<EroHop> hops, boolean isProtect) throws NsoGenException {
+    public NsoLSP makeNsoLSP(Connection conn, VlanJunction thisJunction, VlanJunction otherJunction, List<EroHop> hops, boolean isProtect) throws NsoGenException {
 
-        String lspNamePiece = "-WRK-";
         int holdSetupPriority = 5;
         NsoLspPathType pathType = NsoLspPathType.STRICT;
         if (isProtect) {
-            lspNamePiece = "-PRT-";
             holdSetupPriority = 4;
             pathType = NsoLspPathType.LOOSE;
         }
@@ -181,7 +188,7 @@ public class NsoAdapter {
         if (!isProtect) {
             List<NsoLSP.Hop> nsoHops = new ArrayList<>();
             int i = 1;
-            List<MplsHop> mplsHops = null;
+            List<MplsHop> mplsHops;
             try {
                 mplsHops = miscHelper.mplsHops(hops);
             } catch (PSSException e) {
@@ -197,9 +204,10 @@ public class NsoAdapter {
             }
             mplsPath.setHop(nsoHops);
         }
+        String lspName = lspName(conn, isProtect, otherJunction.getDeviceUrn());
 
         return NsoLSP.builder()
-                .name(connectionId + lspNamePiece + otherJunction.getDeviceUrn())
+                .name(lspName)
                 .device(thisJunction.getDeviceUrn())
                 .primary(mplsPath)
                 .secondary(null)
@@ -208,13 +216,38 @@ public class NsoAdapter {
                         .device(otherJunction.getDeviceUrn())
                         .build())
                 // .metric() we don't need it
-                .routingDomain(ROUTING_DOMAIN)
+                .routingDomain(nsoProperties.getRoutingDomain())
                 .build();
     }
 
+    public static String lspName(Connection c, boolean protect, String target) {
+
+        List<String> parts = new ArrayList<>();
+
+        if (c.getServiceId() != null && !c.getServiceId().isEmpty()) {
+            if (validateServiceId(c.getServiceId())) {
+                parts.add(c.getServiceId());
+            } else {
+                log.info("serviceId "+c.getServiceId()+" did not pass validation");
+            }
+        }
+
+        parts.add(c.getConnectionId());
+        if (protect) {
+            parts.add(PROTECT_LSP_NAME_PIECE);
+        } else {
+            parts.add(WORK_LSP_NAME_PIECE);
+        }
+        parts.add(target);
+
+        return String.join(LSP_NAME_DELIMITER, parts);
+    }
+
+
+
     public NsoOscarsDismantle nsoOscarsDismantle(Connection conn) {
         Integer vcId = nsoVcIdDAO.findNsoVcIdByConnectionId(conn.getConnectionId()).orElseThrow().getVcId();
-        Components cmp = null;
+        Components cmp;
         if (conn.getReserved() != null) {
             cmp = conn.getReserved().getCmp();
         } else {
@@ -222,18 +255,22 @@ public class NsoAdapter {
         }
         List<String> lspInstanceKeys = new ArrayList<>();
         for (VlanPipe pipe : cmp.getPipes()) {
-            String lspNamePiece = "-WRK-";
             // LSP instance key is "lspname,device"
             // we do it both for A-Z and Z-A
-            String azInstanceKey = conn.getConnectionId() + lspNamePiece + pipe.getZ().getDeviceUrn()+","+pipe.getA().getDeviceUrn();
-            String zaInstanceKey = conn.getConnectionId() + lspNamePiece + pipe.getA().getDeviceUrn()+","+pipe.getZ().getDeviceUrn();
+            String azLspName = lspName(conn, false, pipe.getZ().getDeviceUrn());
+            String zaLspName = lspName(conn, false, pipe.getA().getDeviceUrn());
+
+            String azInstanceKey = azLspName+","+pipe.getA().getDeviceUrn();
+            String zaInstanceKey = zaLspName+","+pipe.getZ().getDeviceUrn();
             lspInstanceKeys.add(azInstanceKey);
             lspInstanceKeys.add(zaInstanceKey);
 
             if (pipe.getProtect()) {
-                lspNamePiece = "-PRT-";
-                azInstanceKey = conn.getConnectionId() + lspNamePiece + pipe.getZ().getDeviceUrn()+","+pipe.getA().getDeviceUrn();;
-                zaInstanceKey = conn.getConnectionId() + lspNamePiece + pipe.getA().getDeviceUrn()+","+pipe.getZ().getDeviceUrn();;
+                azLspName = lspName(conn, true, pipe.getZ().getDeviceUrn());
+                zaLspName = lspName(conn, true, pipe.getA().getDeviceUrn());
+
+                azInstanceKey = azLspName+","+pipe.getA().getDeviceUrn();
+                zaInstanceKey = zaLspName+","+pipe.getZ().getDeviceUrn();
                 lspInstanceKeys.add(azInstanceKey);
                 lspInstanceKeys.add(zaInstanceKey);
             }
@@ -255,7 +292,7 @@ public class NsoAdapter {
         if (conn.getReserved().getCmp().getJunctions().size() > 1) {
             for (VlanPipe pipe : conn.getReserved().getCmp().getPipes()) {
                 // primary path
-                NsoLSP azLsp = makeNsoLSP(conn.getConnectionId(), pipe.getA(), pipe.getZ(), pipe.getAzERO(), false);
+                NsoLSP azLsp = makeNsoLSP(conn, pipe.getA(), pipe.getZ(), pipe.getAzERO(), false);
                 LspMapKey azKey = LspMapKey.builder()
                         .device(pipe.getA().getDeviceUrn())
                         .target(pipe.getZ().getDeviceUrn())
@@ -263,7 +300,7 @@ public class NsoAdapter {
                         .build();
                 lspNames.put(azKey, azLsp.getName());
                 lspInstances.add(azLsp);
-                NsoLSP zaLsp = makeNsoLSP(conn.getConnectionId(), pipe.getZ(), pipe.getA(), pipe.getZaERO(), false);
+                NsoLSP zaLsp = makeNsoLSP(conn, pipe.getZ(), pipe.getA(), pipe.getZaERO(), false);
                 LspMapKey zaKey = LspMapKey.builder()
                         .device(pipe.getZ().getDeviceUrn())
                         .target(pipe.getA().getDeviceUrn())
@@ -274,7 +311,7 @@ public class NsoAdapter {
                 lspInstances.add(zaLsp);
 
                 if (pipe.getProtect()) {
-                    NsoLSP azProtectLsp = makeNsoLSP(conn.getConnectionId(), pipe.getA(), pipe.getZ(), pipe.getAzERO(), true);
+                    NsoLSP azProtectLsp = makeNsoLSP(conn, pipe.getA(), pipe.getZ(), pipe.getAzERO(), true);
                     lspInstances.add(azProtectLsp);
                     LspMapKey azProtectKey = LspMapKey.builder()
                             .device(pipe.getA().getDeviceUrn())
@@ -283,7 +320,7 @@ public class NsoAdapter {
                             .build();
                     lspNames.put(azProtectKey, azProtectLsp.getName());
 
-                    NsoLSP zaProtectLsp = makeNsoLSP(conn.getConnectionId(), pipe.getZ(), pipe.getA(), pipe.getZaERO(), true);
+                    NsoLSP zaProtectLsp = makeNsoLSP(conn, pipe.getZ(), pipe.getA(), pipe.getZaERO(), true);
                     lspInstances.add(zaProtectLsp);
                     LspMapKey zaProtectKey = LspMapKey.builder()
                             .device(pipe.getZ().getDeviceUrn())
@@ -475,7 +512,7 @@ public class NsoAdapter {
                 .description(nsoDescription)
                 .name(conn.getConnectionId())
                 .qosMode(NsoVplsQosMode.GUARANTEED)
-                .routingDomain(ROUTING_DOMAIN)
+                .routingDomain(nsoProperties.getRoutingDomain())
                 .vcId(vcid)
                 .sdp(sdps)
                 .device(vplsDeviceMap.values().stream().toList())

--- a/backend/src/main/java/net/es/oscars/sb/nso/NsoProxy.java
+++ b/backend/src/main/java/net/es/oscars/sb/nso/NsoProxy.java
@@ -266,6 +266,9 @@ public class NsoProxy {
             log.error("No device or live status args available");
             return null;
         }
+        if (props.isMockLiveShowCommands()) {
+            return "This is mock data for 'show "+liveStatusRequest.getArgs()+"'";
+        }
         String path = "restconf/data/tailf-ncs:devices/device=" + device + "/live-status/tailf-ned-alu-sr-stats:exec/show";
         String restPath = props.getUri() + path;
 

--- a/backend/src/main/java/net/es/oscars/web/simple/SimpleConnection.java
+++ b/backend/src/main/java/net/es/oscars/web/simple/SimpleConnection.java
@@ -26,6 +26,8 @@ public class SimpleConnection {
     protected Integer heldUntil;
     protected String username;
     protected Phase phase;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    protected String serviceId;
     protected BuildMode mode;
     protected State state;
     @Builder.Default

--- a/frontend/src/main/js/components/design/connectionControls.js
+++ b/frontend/src/main/js/components/design/connectionControls.js
@@ -4,13 +4,12 @@ import { observer, inject } from "mobx-react";
 import { action, autorun } from "mobx";
 import Octicon from "react-octicon";
 import ToggleDisplay from "react-toggle-display";
-import { Alert, Form, Label, Button, Card, CardBody, FormGroup, Input, Collapse } from "reactstrap";
+import { Alert, Form, Label, Button, Card, CardBody, FormGroup, Input } from "reactstrap";
 
 import myClient from "../../agents/client";
 import validator from "../../lib/validation";
 import CommitButton from "./commitButton";
 import HelpPopover from "../helpPopover";
-import TagControls from "./tagControls";
 
 @inject("controlsStore", "designStore", "modalStore")
 @observer
@@ -70,7 +69,12 @@ class ConnectionControls extends Component {
         };
         this.props.controlsStore.setParamsForConnection(params);
     };
-
+    onServiceIdChange = e => {
+        const params = {
+            serviceId: e.target.value
+        };
+        this.props.controlsStore.setParamsForConnection(params);
+    };
     onBuildModeChange = e => {
         const params = {
             mode: e.target.value
@@ -106,7 +110,7 @@ class ConnectionControls extends Component {
                     details page to build / dismantle it.
                 </p>
                 <p>
-                    Mode seleciton is not final. In the connection details page, you can switch
+                    Mode selection is not final. In the connection details page, you can switch
                     between modes, as long as end time has not been reached.
                 </p>
                 <p>In either mode, once end time is reached the connection will be dismantled.</p>
@@ -180,7 +184,7 @@ class ConnectionControls extends Component {
                             <Label>Description:</Label>
                             <Input
                                 type="text"
-                                placeholder="Type a description"
+                                placeholder="Certain special chars not allowed"
                                 valid={validator.descriptionControl(conn.description) === "success"}
                                 invalid={
                                     validator.descriptionControl(conn.description) !== "success"
@@ -210,16 +214,18 @@ class ConnectionControls extends Component {
                             />
                         </FormGroup>
                         <FormGroup>
-                            <Button
-                                color="secondary"
-                                onClick={this.toggle}
-                                style={{ marginBottom: "0.5rem" }}
-                            >
-                                Click to fill project details
-                            </Button>
-                            <Collapse isOpen={this.state.collapse}>
-                                <TagControls />
-                            </Collapse>
+                            {" "}
+                            <Label>Service identifier (optional):</Label>
+                            <Input
+                                type="text"
+                                placeholder="a-zA-Z0-9 length 4-6"
+                                valid={validator.serviceIdControl(conn.serviceId) === "success"}
+                                invalid={
+                                    validator.serviceIdControl(conn.serviceId) !== "success"
+                                }
+                                defaultValue={conn.serviceId}
+                                onChange={this.onServiceIdChange}
+                            />
                         </FormGroup>
                         <FormGroup>
                             <ToggleDisplay show={!conn.validation.acceptable}>

--- a/frontend/src/main/js/components/design/holdTimer.js
+++ b/frontend/src/main/js/components/design/holdTimer.js
@@ -226,6 +226,7 @@ class HoldTimer extends Component {
                 connection_mtu: conn.connection_mtu,
                 mode: conn.mode,
                 description: conn.description,
+                serviceId: conn.serviceId,
                 username: "",
                 phase: "HELD",
                 state: "WAITING",

--- a/frontend/src/main/js/components/details/detailsButtons.js
+++ b/frontend/src/main/js/components/details/detailsButtons.js
@@ -3,10 +3,10 @@ import React, { Component } from "react";
 import { observer, inject } from "mobx-react";
 
 import ConfirmModal from "../confirmModal";
-import { Alert, Button, ListGroup, ListGroupItem, Input, Form, FormGroup } from "reactstrap";
+import { Button, ListGroup, ListGroupItem, Input, Form, FormGroup } from "reactstrap";
 import myClient from "../../agents/client";
 import Moment from "moment/moment";
-import { autorun, action, toJS} from "mobx";
+import { autorun, action } from "mobx";
 import { size } from "lodash-es";
 import HelpPopover from "../helpPopover";
 import { withRouter } from "react-router-dom";
@@ -681,31 +681,6 @@ class DetailsButtons extends Component {
             );
         }
 
-        let regenerate = null;
-        const canRegenerate = controls.regenerate.allowed && !controls.regenerate.working;
-        if (controls.regenerate.show) {
-            showSpecialHeader = true;
-            regenerate = (
-                <ListGroupItem>
-                    <ConfirmModal
-                        body="This will re-generate all router configs. Do NOT use on migrated reservations!"
-                        header="Regenerate configs"
-                        uiElement={
-                            <Button
-                                className="pull-right"
-                                disabled={!canRegenerate}
-                                color="warning"
-                            >
-                                Regenerate router config
-                            </Button>
-                        }
-                        onConfirm={this.doRegenCommands}
-                    />{" "}
-                    {this.help("regenerate")}
-                </ListGroupItem>
-            );
-        }
-
         let controlsHeader = null;
         if (controls.show) {
             controlsHeader = <ListGroupItem color="info">Controls {overallHelp}</ListGroupItem>;
@@ -762,7 +737,6 @@ class DetailsButtons extends Component {
                 {release}
                 <br />
                 {specialHeader}
-                {regenerate}
                 <br />
                 {cloneButton}
                 <br />

--- a/frontend/src/main/js/components/details/detailsControls.js
+++ b/frontend/src/main/js/components/details/detailsControls.js
@@ -4,7 +4,7 @@ import { observer, inject } from "mobx-react";
 
 import { withRouter } from "react-router-dom";
 
-import { Button, Card, CardBody, CardHeader, FormGroup, Label, Input } from "reactstrap";
+import {Button, Card, CardBody, CardHeader, Label, Input, InputGroup} from "reactstrap";
 import PropTypes from "prop-types";
 
 @inject("connsStore", "commonStore")
@@ -38,9 +38,10 @@ class DetailsControls extends Component {
             <Card>
                 <CardHeader>Search</CardHeader>
                 <CardBody>
-                    <FormGroup>
-                        <Label>Connection ID:</Label>{" "}
+                    <InputGroup>
+                        <Label hidden for="connectionId">Connection ID:</Label>
                         <Input
+                            id="connectionId"
                             type="text"
                             innerRef={ref => {
                                 this.connectionIdRef = ref;
@@ -49,28 +50,27 @@ class DetailsControls extends Component {
                             onKeyPress={this.handleKeyPress}
                             placeholder='Connection ID ("Z0K2")'
                         />
-                    </FormGroup>
+                        <Button
+                            color="info"
+                            disabled={!connLoaded}
+                            onClick={() => {
+                                this.props.refresh();
+                            }}
+                            className="float-left"
+                        >
+                            Refresh
+                        </Button>
+                        <Button
+                            color="primary"
+                            onClick={() => {
+                                this.load();
+                            }}
+                            className="float-right"
+                        >
+                            Load
+                        </Button>
 
-                    <Button
-                        color="info"
-                        disabled={!connLoaded}
-                        onClick={() => {
-                            this.props.refresh();
-                        }}
-                        className="float-left"
-                    >
-                        Refresh
-                    </Button>
-
-                    <Button
-                        color="primary"
-                        onClick={() => {
-                            this.load();
-                        }}
-                        className="float-right"
-                    >
-                        Load
-                    </Button>
+                    </InputGroup>
                 </CardBody>
             </Card>
         );

--- a/frontend/src/main/js/components/details/detailsEditForm.js
+++ b/frontend/src/main/js/components/details/detailsEditForm.js
@@ -1,24 +1,9 @@
-import React, { Component } from "react";
+import React, {Component} from "react";
 import chrono from "chrono-node";
-import { action } from "mobx";
-import { observer, inject } from "mobx-react";
+import {action} from "mobx";
+import {inject, observer} from "mobx-react";
 import Moment from "moment";
-import {
-    Alert,
-    Button,
-    Collapse,
-    Col,
-    Form,
-    FormFeedback,
-    FormGroup,
-    FormText,
-    Input,
-    Label,
-    Modal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader
-} from "reactstrap";
+import {Button, Col, Collapse, Form, FormFeedback, FormGroup, FormText, Input, InputGroup, Label} from "reactstrap";
 import ToggleDisplay from "react-toggle-display";
 
 import myClient from "../../agents/client";
@@ -115,7 +100,7 @@ class DetailsEditForm extends Component {
         });
     };
 
-    handleDescriptionSave = e => {
+    handleDescriptionSave = () => {
         const conn = this.props.connsStore.store.current;
         const desc = this.props.connsStore.editSchedule.description;
         const modification = {
@@ -240,11 +225,10 @@ class DetailsEditForm extends Component {
 
         // Format input box text
         const splitValue = this.endingDate.value.split(" ");
-        const formattedEnding = splitValue[0] + " " + splitValue[1];
-        this.endingDate.value = formattedEnding;
+        this.endingDate.value = splitValue[0] + " " + splitValue[1];
     };
 
-    handleEndingSave = e => {
+    handleEndingSave = () => {
         const conn = this.props.connsStore.store.current;
         const ending = this.props.connsStore.editSchedule.ending;
         const modification = {
@@ -288,55 +272,51 @@ class DetailsEditForm extends Component {
 
         return (
             <Form>
-                <FormGroup row>
+                <InputGroup>
                     <Label for="description" sm={2}>
                         Description
                     </Label>
-                    <Col sm={7}>
-                        <Input
-                            type="text"
-                            defaultValue={conn.description}
-                            innerRef={ref => {
-                                this.description = ref;
-                            }}
-                            disabled={es.description.buttons.input}
-                            invalid={es.description.validationState === "error"}
-                            onChange={this.handleDescriptionChange}
-                        />
-                        <FormFeedback>{es.description.validationText}</FormFeedback>
-                        {es.description.saved === true ? (
-                            <DetailsModal name="editDescription" />
-                        ) : (
-                            ""
-                        )}
-                        <Collapse isOpen={!es.description.buttons.collapseText}>
-                            <FormGroup>
-                                <FormText>
-                                    Original Description: {es.description.originalDescription}
-                                </FormText>
-                            </FormGroup>
-                        </Collapse>
-                    </Col>
-                    <Col sm={1.5}>
-                        <ToggleDisplay show={es.description.buttons.buttonText === "Edit"}>
-                            <Button color="primary" onClick={this.handleDescriptionEdit}>
-                                Edit
-                            </Button>
-                        </ToggleDisplay>
-                        <ToggleDisplay show={es.description.buttons.buttonText === "Cancel"}>
-                            <Button color="primary" onClick={this.handleDescriptionCancel}>
-                                Cancel
-                            </Button>
-                        </ToggleDisplay>
-                    </Col>
-                    <Col sm={1}>
-                        <Button
-                            color="success"
-                            disabled={es.description.buttons.save}
-                            onClick={this.handleDescriptionSave}
-                        >
-                            Save
+                    <Input
+                        type="text"
+                        defaultValue={conn.description}
+                        innerRef={ref => {
+                            this.description = ref;
+                        }}
+                        disabled={es.description.buttons.input}
+                        invalid={es.description.validationState === "error"}
+                        onChange={this.handleDescriptionChange}
+                    />
+                    <FormFeedback>{es.description.validationText}</FormFeedback>
+                    {es.description.saved === true ? (
+                        <DetailsModal name="editDescription" />
+                    ) : (
+                        ""
+                    )}
+                    <ToggleDisplay show={es.description.buttons.buttonText === "Edit"}>
+                        <Button color="primary" onClick={this.handleDescriptionEdit}>
+                            Edit
                         </Button>
+                    </ToggleDisplay>
+                    <ToggleDisplay show={es.description.buttons.buttonText === "Cancel"}>
+                        <Button color="primary" onClick={this.handleDescriptionCancel}>
+                            Cancel
+                        </Button>
+                    </ToggleDisplay>
+                    <Button
+                        color="success"
+                        disabled={es.description.buttons.save}
+                        onClick={this.handleDescriptionSave}
+                    >
+                        Save
+                    </Button>
+                </InputGroup>
+
+                <FormGroup row>
+                    <Label for="serviceId" sm={2}>
+                        ServiceId
+                    </Label>
+                    <Col sm={10}>
+                        <Input type="text" defaultValue={conn.serviceId} disabled />
                     </Col>
                 </FormGroup>
 
@@ -358,59 +338,53 @@ class DetailsEditForm extends Component {
                     </Col>
                 </FormGroup>
 
-                <FormGroup row>
+                <InputGroup>
                     <Label for="ending" sm={2}>
                         Ending
                     </Label>
-                    <Col sm={7}>
-                        <Input
-                            type="text"
-                            defaultValue={es.ending.originalTime}
-                            innerRef={ref => {
-                                this.endingDate = ref;
-                            }}
-                            disabled={es.ending.buttons.input}
-                            invalid={es.ending.validationState === "error"}
-                            onChange={this.handleEndingChange}
-                        />
-                        <FormFeedback>{es.ending.validationText}</FormFeedback>
-                        {es.ending.saved ? <DetailsModal name="editEnding" /> : ""}
-                        <Collapse isOpen={!es.ending.buttons.collapseText}>
-                            <FormGroup>
-                                <FormText>Original Ending Time: {es.ending.originalTime}</FormText>
-                                <FormText>
-                                    Valid Range between {validStartingTime} to {validEndingTime}
-                                </FormText>
-                                <FormText>{`Parsed Value: ${es.ending.parsedValue}`}</FormText>
-                            </FormGroup>
-                        </Collapse>
-                    </Col>
-                    <Col sm={1.5}>
-                        <ToggleDisplay show={es.ending.buttons.buttonText === "Edit"}>
-                            <Button 
-                                color="primary" 
-                                disabled={conn.phase === "ARCHIVED" ? true : false} 
-                                onClick={this.handleEndingEdit}
-                            >
-                                Edit
-                            </Button>
-                        </ToggleDisplay>
-                        <ToggleDisplay show={es.ending.buttons.buttonText === "Cancel"}>
-                            <Button color="primary" onClick={this.handleEndingCancel}>
-                                Cancel
-                            </Button>
-                        </ToggleDisplay>
-                    </Col>
-                    <Col sm={1}>
+                    <Input
+                        type="text"
+                        defaultValue={es.ending.originalTime}
+                        innerRef={ref => {
+                            this.endingDate = ref;
+                        }}
+                        disabled={es.ending.buttons.input}
+                        invalid={es.ending.validationState === "error"}
+                        onChange={this.handleEndingChange}
+                    />
+                    <FormFeedback>{es.ending.validationText}</FormFeedback>
+                    {es.ending.saved ? <DetailsModal name="editEnding" /> : ""}
+                    <Collapse isOpen={!es.ending.buttons.collapseText}>
+                        <FormGroup>
+                            <FormText>Original Ending Time: {es.ending.originalTime}</FormText>
+                            <FormText>
+                                Valid Range between {validStartingTime} to {validEndingTime}
+                            </FormText>
+                            <FormText>{`Parsed Value: ${es.ending.parsedValue}`}</FormText>
+                        </FormGroup>
+                    </Collapse>
+                    <ToggleDisplay show={es.ending.buttons.buttonText === "Edit"}>
                         <Button
-                            color="success"
-                            disabled={es.ending.buttons.save}
-                            onClick={this.handleEndingSave}
+                            color="primary"
+                            disabled={conn.phase === "ARCHIVED"}
+                            onClick={this.handleEndingEdit}
                         >
-                            Save
+                            Edit
                         </Button>
-                    </Col>
-                </FormGroup>
+                    </ToggleDisplay>
+                    <ToggleDisplay show={es.ending.buttons.buttonText === "Cancel"}>
+                        <Button color="primary" onClick={this.handleEndingCancel}>
+                            Cancel
+                        </Button>
+                    </ToggleDisplay>
+                    <Button
+                        color="success"
+                        disabled={es.ending.buttons.save}
+                        onClick={this.handleEndingSave}
+                    >
+                        Save
+                    </Button>
+                </InputGroup>
             </Form>
         );
     }

--- a/frontend/src/main/js/components/details/detailsGeneral.js
+++ b/frontend/src/main/js/components/details/detailsGeneral.js
@@ -14,11 +14,9 @@ import {
 } from "reactstrap";
 import classnames from "classnames";
 
-// import DetailsButtons from "./detailsButtons";
 import DetailsDrawing from "./detailsDrawing";
 import DetailsEditForm from "./detailsEditForm";
 import DetailsHistory from "./detailsHistory";
-import DetailsTags from "./detailsTags";
 import HelpPopover from "../helpPopover";
 import DetailsTroubleshoot from "./detailsTroubleshoot";
 
@@ -116,17 +114,6 @@ class DetailsGeneral extends Component {
                             <NavItem>
                                 <NavLink
                                     href="#"
-                                    className={classnames({ active: this.state.tab === "tags" })}
-                                    onClick={() => {
-                                        this.setTab("tags");
-                                    }}
-                                >
-                                    Tags
-                                </NavLink>
-                            </NavItem>
-                            <NavItem>
-                                <NavLink
-                                    href="#"
                                     className={classnames({ active: this.state.tab === "drawing" })}
                                     onClick={() => {
                                         this.setTab("drawing");
@@ -167,9 +154,6 @@ class DetailsGeneral extends Component {
                                 {/* <br /> */}
                                 {/* <DetailsButtons /> */}
                             </TabPane>
-                            <TabPane tabId="tags" title="Tags">
-                                <DetailsTags />
-                            </TabPane>
                             <TabPane tabId="drawing" title="Drawing">
                                 <DetailsDrawing />
                             </TabPane>
@@ -188,7 +172,7 @@ class DetailsGeneral extends Component {
         }
     }
 
-    phaseHelp(phase) {
+    phaseHelp() {
         const header = <span>Phase help</span>;
         let body = (
             <span>
@@ -215,7 +199,7 @@ class DetailsGeneral extends Component {
         );
     }
 
-    stateHelp(state) {
+    stateHelp() {
         const header = <span>State help</span>;
         let body = (
             <span>
@@ -244,7 +228,7 @@ class DetailsGeneral extends Component {
         );
     }
 
-    modeHelp(mode) {
+    modeHelp() {
         const header = <span>Build mode help</span>;
         let body = (
             <span>

--- a/frontend/src/main/js/components/details/detailsTroubleshoot.js
+++ b/frontend/src/main/js/components/details/detailsTroubleshoot.js
@@ -8,10 +8,9 @@ import {
     CardBody,
     Button,
     Form,
-    UncontrolledAccordion,
     AccordionItem,
     AccordionHeader,
-    AccordionBody
+    AccordionBody, Accordion
 } from "reactstrap";
 
 import myClient from "../../agents/client";
@@ -22,17 +21,14 @@ class DetailsTroubleshoot extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            loading: true
+            loading: true,
+            open: ''
         };
     }
 
     componentWillMount() {
         const connectionId = this.props.connsStore.store.current.connectionId;
         this.updateMacInfo(connectionId);
-    }
-
-    componentWillUnmount() {
-        // this.props.connsStore.clearCurrent();
     }
 
     refresh = () => {
@@ -47,7 +43,7 @@ class DetailsTroubleshoot extends Component {
         if (this.props.connsStore.store.current.phase !== 'RESERVED') {
             return;
         }
-
+        this.setState({loading: true})
 
         myClient.submitWithToken("POST", "/api/mac/info", macInfoRequest).then(
             action(response => {
@@ -58,18 +54,25 @@ class DetailsTroubleshoot extends Component {
         );
     };
 
+    toggle = (id) => {
+        if (this.state.open === id) {
+            this.setState({open : ''})
+        } else {
+            this.setState({open : id})
+        }
+    };
 
     render() {
         let cs = this.props.connsStore;
         const macInfo = cs.store.macInfo;
         let contents = <div>Loading..</div>;
         if (cs.store.current.phase !== 'RESERVED') {
-            contents = '<p>Only available for RESERVED connections</p>'
+            contents = <pre>Only available for RESERVED connections</pre>
         } else if (!this.state.loading) {
 
             let macLearning = <div>No mac learning data loaded</div>
             if (macInfo['connection-id']) {
-                macLearning = <UncontrolledAccordion>
+                macLearning = <Accordion  open={this.state.open} toggle={this.toggle} >
                     {
                         macInfo['results'].map((result, idx) => {
                             let message = result['fdb'];
@@ -82,16 +85,16 @@ class DetailsTroubleshoot extends Component {
                             }
                             let headerString = result['device'] + ' (' + timestamp + ')';
                             return <AccordionItem key={idx}>
-                                <AccordionHeader targetId={idx}>{headerString}</AccordionHeader>
-                                <AccordionBody accordionId={idx}>
+                                <AccordionHeader targetId={idx+""}>{headerString}</AccordionHeader>
+                                <AccordionBody accordionId={idx+""}>
                                     <pre>{message}</pre>
                                 </AccordionBody>
                             </AccordionItem>
                         })
                     }
-                </UncontrolledAccordion>
+                </Accordion>
             }
-            contents = <Form inline onSubmit={e => {
+            contents = <Form inline="true" onSubmit={e => {
                 e.preventDefault();
             }}>
                 {macLearning}

--- a/frontend/src/main/js/lib/validation.js
+++ b/frontend/src/main/js/lib/validation.js
@@ -1,7 +1,6 @@
 import React from "react";
 import Octicon from "react-octicon";
 import { Graph, alg } from "graphlib";
-import { toJS } from "mobx";
 
 class Validator {
     label(state) {
@@ -26,17 +25,13 @@ class Validator {
     }
 
     fixtureState(fixture) {
-        if (!fixture.locked) {
-            return false;
-        }
-        return true;
+        return fixture.locked;
+
     }
 
     pipeState(pipe) {
-        if (!pipe.locked) {
-            return false;
-        }
-        return true;
+        return pipe.locked;
+
     }
 
     fixtureMapColor(fixture) {
@@ -123,10 +118,8 @@ class Validator {
             g.setEdge(p.a, p.z, p.a + " - " + p.z);
         });
         const connected = alg.components(g);
-        if (connected.length === 1) {
-            return true;
-        }
-        return false;
+        return connected.length === 1;
+
     }
 
     validateConnection(params) {
@@ -212,7 +205,26 @@ class Validator {
         if (val === "") {
             return "error";
         }
-        return "success";
+        if (/^[a-zA-Z0-9\s\]\[)(@!#%{};<>._-]+$/.test(val)) {
+            return "success";
+        }
+        return "error"
+    }
+    serviceIdControl(val) {
+        if (typeof val === "undefined") {
+            return "success";
+        }
+        if (val.length === 0) {
+            return "success";
+        }
+        if (val.length > 0 && val.length < 4) {
+            return "error";
+        }
+        // must be alphanumeric
+        if (/^[a-zA-Z0-9]+$/.test(val)) {
+            return "success";
+        }
+        return "error";
     }
 
     mtuControl(val) {

--- a/frontend/src/main/js/stores/connsStore.js
+++ b/frontend/src/main/js/stores/connsStore.js
@@ -15,6 +15,7 @@ class ConnectionsStore {
                     ending: null
                 }
             },
+            serviceId: "",
             tags: [],
             dirty: false
         },
@@ -242,10 +243,7 @@ class ConnectionsStore {
                 let conn = JSON.parse(response);
                 transformer.fixSerialization(conn);
                 this.setCurrent(conn);
-            }),
-            failure => {
-                // do nothing
-            }
+            })
         );
     }
 


### PR DESCRIPTION
backend:
- a new `serviceId` column in Connection and associated types
- centralized NSO LSP naming into a function, LSP names prefixed with serviceId if it exists
- new properties:
  - `nso.routing-domain` externalizes the hardcoded routing domain
  - `nso.mock-live-show-commands` enables mocking of show commands where those are not available

frontend
- new `serviceId` control
- removed tags tab (and will completely remove soon)
- added some validation for connection description
- fixed some glitched button placements

### Description

