### PR TITLE
fix: [OS-374] Replace keycloak-east.es.net with sso-dev.es.net

### DIFF
--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -116,8 +116,8 @@ auth.user-groups[1]=svc_oscars_admin
 auth.admin-groups[0]=svc_oscars_admin
 
 # basically all this oauth stuff needs to be coordinated with the OAuth provider
-spring.security.oauth2.resourceserver.jwt.issuer-uri=https://sso-dev.es.net/auth/realms/esnet_keycloak
-spring.security.oauth2.client.provider.keycloak.issuer-uri=https://sso-dev.es.net/auth/realms/esnet_keycloak
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://sso-dev.es.net/auth/realms/an_esnet
+spring.security.oauth2.client.provider.keycloak.issuer-uri=https://sso-dev.es.net/auth/realms/an_esnet
 spring.security.oauth2.client.provider.keycloak.user-name-attribute=preferred_username
 spring.security.oauth2.client.registration.keycloak.client-id=local-oscars-backend
 spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
@@ -143,9 +143,9 @@ otel.service.version=1.2
 
 
 frontend.oauth-client-id=local-oscars-frontend
-frontend.oauth-auth-endpoint=https://sso-dev.es.net/auth/realms/esnet_keycloak/protocol/openid-connect/auth
-frontend.oauth-token-endpoint=https://sso-dev.es.net/auth/realms/esnet_keycloak/protocol/openid-connect/token
-frontend.oauth-logout-endpoint=https://sso-dev.es.net/auth/realms/esnet_keycloak/protocol/openid-connect/logout
+frontend.oauth-auth-endpoint=https://sso-dev.es.net/auth/realms/an_esnet/protocol/openid-connect/auth
+frontend.oauth-token-endpoint=https://sso-dev.es.net/auth/realms/an_esnet/protocol/openid-connect/token
+frontend.oauth-logout-endpoint=https://sso-dev.es.net/auth/realms/an_esnet/protocol/openid-connect/logout
 # this redirect must match what is configured on the oauth server for that client-id
 frontend.oauth-redirect-uri=http://localhost:8181/
 frontend.oauth-scope=openid

--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -116,8 +116,8 @@ auth.user-groups[1]=svc_oscars_admin
 auth.admin-groups[0]=svc_oscars_admin
 
 # basically all this oauth stuff needs to be coordinated with the OAuth provider
-spring.security.oauth2.resourceserver.jwt.issuer-uri=https://keycloak-east.es.net/auth/realms/esnet_keycloak
-spring.security.oauth2.client.provider.keycloak.issuer-uri=https://keycloak-east.es.net/auth/realms/esnet_keycloak
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://sso-dev.es.net/auth/realms/esnet_keycloak
+spring.security.oauth2.client.provider.keycloak.issuer-uri=https://sso-dev.es.net/auth/realms/esnet_keycloak
 spring.security.oauth2.client.provider.keycloak.user-name-attribute=preferred_username
 spring.security.oauth2.client.registration.keycloak.client-id=local-oscars-backend
 spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
@@ -143,9 +143,9 @@ otel.service.version=1.2
 
 
 frontend.oauth-client-id=local-oscars-frontend
-frontend.oauth-auth-endpoint=https://keycloak-east.es.net/auth/realms/esnet_keycloak/protocol/openid-connect/auth
-frontend.oauth-token-endpoint=https://keycloak-east.es.net/auth/realms/esnet_keycloak/protocol/openid-connect/token
-frontend.oauth-logout-endpoint=https://keycloak-east.es.net/auth/realms/esnet_keycloak/protocol/openid-connect/logout
+frontend.oauth-auth-endpoint=https://sso-dev.es.net/auth/realms/esnet_keycloak/protocol/openid-connect/auth
+frontend.oauth-token-endpoint=https://sso-dev.es.net/auth/realms/esnet_keycloak/protocol/openid-connect/token
+frontend.oauth-logout-endpoint=https://sso-dev.es.net/auth/realms/esnet_keycloak/protocol/openid-connect/logout
 # this redirect must match what is configured on the oauth server for that client-id
 frontend.oauth-redirect-uri=http://localhost:8181/
 frontend.oauth-scope=openid


### PR DESCRIPTION
### Description

[keycloak-east.es.net](http://keycloak-east.es.net/) has been shut down. All references to URLs in configuration that use that host need to be migrated to [sso-dev.es.net](http://sso-dev.es.net/). Additionally, work is needed to coordinate with Platform Team to migrate the oscars to the new keycloak host.

### Checklist

- [X] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [x] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [x] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
