### PR TITLE
fix: [OS-387] don't send out ancient terminated connections

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,9 @@ include:
 
 workflow:
   rules:
-    - if: $CI_PIPELINE_SOURCE != "merge_request_event"
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_TAG
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
 .wharf_logout: &wharf_logout |-
   docker logout "$WHARF_SITE"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 # OSCARS Release Notes
+### 1.2.18
+> Jan 2025
+- NSI response size hotfix
+
 ### 1.2.15
 > Oct 2024
 - NSI modify hotfix

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -14,7 +14,7 @@
     <groupId>net.es.oscars</groupId>
     <artifactId>backend</artifactId>
     <name>backend</name>
-    <version>1.2.17</version>
+    <version>1.2.18</version>
 
     <description>OSCARS backend</description>
     <properties>

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
@@ -752,6 +752,13 @@ public class NsiService {
             return null;
         }
         Connection c = mc.get();
+        if (c.getPhase().equals(Phase.ARCHIVED)) {
+            // if this is archived and the end date was 24 hours ago or more, don't return it
+            if (c.getArchived().getSchedule()
+                    .getEnding().isBefore(Instant.now().minus(24L, ChronoUnit.HOURS))) {
+                return null;
+            }
+        }
 
         QuerySummaryResultType qsrt = new QuerySummaryResultType();
         qsrt.setConnectionId(mapping.getNsiConnectionId());


### PR DESCRIPTION
### Description

small change in code to remove some old / irrelevant connections from a query response

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
