### PR TITLE
feat: [OS-309] Add support for 'untagged' ports. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### 1.2.19
 > Jan 2025
-- Support for 'untagged' (`EthernetEncapsulation.NULL`) ports, `features.untagged-ports` flag added.
+- Support for 'untagged' (`EthernetEncapsulation.NULL`) and QINQ (`EthernetEncapsulation.QINQ`) ethernet encapsulation labeling. Application properties `features.untagged-ports` and `features.qinq-ports` flags added.
 
 ### 1.2.18
 > Jan 2025

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
 # OSCARS Release Notes
+
+### 1.2.19
+> Jan 2025
+- Support for 'untagged' (`EthernetEncapsulation.NULL`) ports, `features.untagged-ports` flag added.
+
 ### 1.2.18
 > Jan 2025
 - NSI response size hotfix

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -3,6 +3,19 @@ This file contains instructions for updating an existing installation of OSCARS 
 
 Instructions include config file changes, database schema changes, etc.
 
+## v1.2.18 to 1.2.19
+Assert this exists in `application.properties`:
+```
+# Support for untagged ports in topo-common version 0.0.31 or higher.
+# See https://esnet.atlassian.net/browse/OCD-613
+# Enabled = true. Disabled = false.
+# Default: false.
+#
+# Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation property (enumeration).
+# Disabled: Ingest Port objects and IGNORE the ethernetEncapsulation property (enumeration).
+features.untagged-ports=false
+```
+
 ## v1.1.3 to 1.1.4
 ### backend
 Add these to `application.properties`:

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -10,10 +10,16 @@ Assert this exists in `application.properties`:
 # See https://esnet.atlassian.net/browse/OCD-613
 # Enabled = true. Disabled = false.
 # Default: false.
-#
-# Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation property (enumeration).
-# Disabled: Ingest Port objects and IGNORE the ethernetEncapsulation property (enumeration).
+
+# Process untagged 'NULL' ethernet encapsulation ports from topology discovery:
+# Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation.NULL enum type.
+# Disabled: Ingest Port objects and IGNORE the ethernetEncapsulation.NULL enum type.
 features.untagged-ports=false
+
+# Process QINQ ethernet encapsulation ports from topology discovery:
+# Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation.QINQ enum type.
+# Disabled: Ingest Port objects and IGNORE the ethernetEncapsulation.QINQ enum type.
+features.qinq-ports=false
 ```
 
 ## v1.1.3 to 1.1.4

--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -180,7 +180,13 @@ esdb.vlan-sync-period=PT5M
 # See https://esnet.atlassian.net/browse/OCD-613
 # Enabled = true. Disabled = false.
 # Default: false.
-#
-# Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation property (enumeration).
-# Disabled: Ingest Port objects and IGNORE the ethernetEncapsulation property (enumeration).
+
+# Process untagged 'NULL' ethernet encapsulation ports from topology discovery:
+# Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation.NULL enum type.
+# Disabled: Ingest Port objects and IGNORE the ethernetEncapsulation.NULL enum type.
 features.untagged-ports=false
+
+# Process QINQ ethernet encapsulation ports from topology discovery:
+# Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation.QINQ enum type.
+# Disabled: Ingest Port objects and IGNORE the ethernetEncapsulation.QINQ enum type.
+features.qinq-ports=false

--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -183,4 +183,4 @@ esdb.vlan-sync-period=PT5M
 #
 # Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation property (enumeration).
 # Disabled: Ingest Port objects and IGNORE the ethernetEncapsulation property (enumeration).
-features.untagged-ports=true
+features.untagged-ports=false

--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -175,3 +175,12 @@ esdb.enabled=true
 # format this period like
 # https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)
 esdb.vlan-sync-period=PT5M
+
+# Support for untagged ports in topo-common version 0.0.31 or higher.
+# See https://esnet.atlassian.net/browse/OCD-613
+# Enabled = true. Disabled = false.
+# Default: false.
+#
+# Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation property (enumeration).
+# Disabled: Ingest Port objects and IGNORE the ethernetEncapsulation property (enumeration).
+features.untagged-ports=true

--- a/backend/src/main/java/net/es/oscars/app/props/FeaturesProperties.java
+++ b/backend/src/main/java/net/es/oscars/app/props/FeaturesProperties.java
@@ -1,0 +1,18 @@
+package net.es.oscars.app.props;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@EnableConfigurationProperties(FeaturesProperties.class)
+@ConfigurationProperties(prefix = "features")
+@NoArgsConstructor
+public class FeaturesProperties {
+    @NonNull
+    private Boolean untaggedPorts = false;
+}

--- a/backend/src/main/java/net/es/oscars/app/props/FeaturesProperties.java
+++ b/backend/src/main/java/net/es/oscars/app/props/FeaturesProperties.java
@@ -15,4 +15,6 @@ import org.springframework.context.annotation.Configuration;
 public class FeaturesProperties {
     @NonNull
     private Boolean untaggedPorts = false;
+    @NonNull
+    private Boolean qinqPorts = false;
 }

--- a/backend/src/main/java/net/es/oscars/topo/pop/TopoPopulator.java
+++ b/backend/src/main/java/net/es/oscars/topo/pop/TopoPopulator.java
@@ -163,14 +163,20 @@ public class TopoPopulator {
                     .build();
             devices.put(d.getUrn(), d);
             for (OscarsOnePort discPort : discDevice.getPorts()) {
-                // If this is an 'untagged' port, and features.untagged_ports is disabled,
-                // just skip this port.
+                // If this is an 'untagged' port, and features.untagged-ports is disabled, skip.
+                // If this is a QINQ port, and features.qinq-ports is disabled, skip.
                 if (
-                    featuresProperties.getUntaggedPorts() == false
-                    && discPort.getEthernetEncapsulation() == EthernetEncapsulation.NULL
+
+                    ( featuresProperties.getUntaggedPorts() == false
+                      && discPort.getEthernetEncapsulation() == EthernetEncapsulation.NULL )
+
+                    || ( featuresProperties.getQinqPorts() == false
+                      && discPort.getEthernetEncapsulation() == EthernetEncapsulation.QINQ )
                 ) {
                     continue;
                 }
+
+
                 Set<Layer> portCaps = new HashSet<>();
                 for (OscarsOneCapability os1Cap : discPort.getCapabilities()) {
                     portCaps.add(Layer.valueOf(os1Cap.toString()));


### PR DESCRIPTION
Adds a new application property `features.untagged-ports`, boolean. Defaults to `false` (disabled) for now.

### Description

Adding a flag to enable or disable processing of untagged ports from the `topology-discovery` service. The backend service will ignore any untagged ports (`EthernetEncapsulation.NULL`) if `features.untagged-ports` in application.properties is set to `false`, otherwise, the untagged ports will be processed in `TopoPopulator.java::loadTopology()`

See Jira issue at:
https://esnet.atlassian.net/browse/OS-309


### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [x] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [x ] This PR has updated documentation as appropriate
- [ ] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
