### PR TITLE
fix [OS-402] Adding support for JAVA_OPTS docker build args and env vars.

### DIFF
--- a/deploy/devel/frontend.dockerfile
+++ b/deploy/devel/frontend.dockerfile
@@ -12,7 +12,6 @@ COPY public ./public
 
 RUN npm install
 ENV NODE_OPTIONS=--openssl-legacy-provider
-
 EXPOSE 3000
 
 # we count on our volumes at

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
       - topo-net
     build:
       context: ./
+      args:
+        JAVA_OPTS: "-XX:UseSVE=0"
+        MAVEN_OPTS: "-XX:UseSVE=0"
       dockerfile: ./deploy/devel/backend.dockerfile
     depends_on:
       oscars-db:
@@ -18,6 +21,8 @@ services:
     ports:
       - "${OSCARS_BACKEND_WEB_PORT:-8201}:${OSCARS_BACKEND_WEB_PORT:-8201}"
     environment:
+      JAVA_OPTS: "-XX:UseSVE=0"
+      MAVEN_OPTS: "-XX:UseSVE=0"
       OSCARS_BACKEND_WEB_PORT: ${OSCARS_BACKEND_WEB_PORT:-8201}
       SPRING_DATASOURCE_URL: jdbc:postgresql://oscars-db:5432/${POSTGRES_DB:-oscars}
       POSTGRES_USER: ${POSTGRES_USER:-oscars}


### PR DESCRIPTION
Allows us to set `-XX:UseSVE=0` to disable Scalable Vector Extension use with java and maven, as with UseSVE enabled, Apple ARM M4 chipset hosts and docker containers will fail to run the java CLI

### Description

**INCLUDE PR DESCRIPTION**

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [ ] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
