### PR TITLE
fix: [OS-434] Fix esnet status

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ backend:test:
 
 .backend:push:
   stage: push
-  needs: ["backend:scan"]
+  needs: ["backend:scan", "backend:test"]
   before_script:
     - *docker_login
     - *wharf_login

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
@@ -1358,7 +1358,7 @@ public class NsiService {
 
         TypeValueType tvt = new TypeValueType();
         tvt.setType("oscarsId");
-        tvt.setType(mapping.getOscarsConnectionId());
+        tvt.setValue(mapping.getOscarsConnectionId());
         p2p.getParameter().add(tvt);
 
         VlanFixture a = cmp.getFixtures().get(0);

--- a/backend/src/main/java/net/es/oscars/sb/nso/NsoProxy.java
+++ b/backend/src/main/java/net/es/oscars/sb/nso/NsoProxy.java
@@ -424,10 +424,15 @@ public class NsoProxy {
         StringBuilder errorStr = new StringBuilder();
         errorStr.append("esnet-status error\n");
         final HttpEntity<LiveStatusRequest> requestEntity = new HttpEntity<>(liveStatusRequest);
-        // first, try to get a LiveStatusOutput
-        ResponseEntity<LiveStatusOutput> responseEntity = restTemplate.postForEntity(restPath, requestEntity, LiveStatusOutput.class);
-        // if we get an error, try again...
-        if (responseEntity.getStatusCode().isError()) {
+        // first, try to get a
+        try {
+            ResponseEntity<LiveStatusOutput> responseEntity = restTemplate.postForEntity(restPath, requestEntity, LiveStatusOutput.class);
+            if (responseEntity.getBody() != null) {
+                return responseEntity.getBody().getOutput();
+            } else {
+                errorStr.append("null response body\n");
+            }
+        } catch (RestClientException ex) {
             // but this time, try to deserialize into a IetfRestconfErrorResponse so we can grab the error messages
             ResponseEntity<IetfRestconfErrorResponse> errorResponse = restTemplate.postForEntity(restPath, requestEntity, IetfRestconfErrorResponse.class);
             if (errorResponse.getBody() != null) {
@@ -437,13 +442,8 @@ public class NsoProxy {
             } else {
                 errorStr.append("null error body\n");
             }
-        } else {
-            if (responseEntity.getBody() != null) {
-                return responseEntity.getBody().getOutput();
-            } else {
-                errorStr.append("null response body\n");
-            }
         }
+
         return errorStr.toString();
     }
 

--- a/backend/src/main/java/net/es/oscars/sb/nso/NsoProxy.java
+++ b/backend/src/main/java/net/es/oscars/sb/nso/NsoProxy.java
@@ -20,7 +20,6 @@ import net.es.oscars.sb.nso.rest.NsoServicesWrapper;
 import net.es.oscars.sb.nso.rest.LiveStatusRequest;
 import net.es.oscars.sb.nso.rest.LiveStatusMockData;
 import net.es.oscars.sb.nso.rest.LiveStatusOutput;
-import net.es.oscars.web.beans.LiveStatusResponse;
 import net.es.topo.common.devel.DevelUtils;
 import net.es.topo.common.dto.nso.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -424,7 +423,7 @@ public class NsoProxy {
         StringBuilder errorStr = new StringBuilder();
         errorStr.append("esnet-status error\n");
         final HttpEntity<LiveStatusRequest> requestEntity = new HttpEntity<>(liveStatusRequest);
-        // first, try to get a
+        // first, try to get a LiveStatusOutput
         try {
             ResponseEntity<LiveStatusOutput> responseEntity = restTemplate.postForEntity(restPath, requestEntity, LiveStatusOutput.class);
             if (responseEntity.getBody() != null) {
@@ -433,7 +432,10 @@ public class NsoProxy {
                 errorStr.append("null response body\n");
             }
         } catch (RestClientException ex) {
-            // but this time, try to deserialize into a IetfRestconfErrorResponse so we can grab the error messages
+            // if we get an exception, the underlying exception could be a HttpMessageNotReadableException
+            // because the actual response is an IetfRestconfErrorResponse
+
+            // we try again, but this time, try to deserialize into that class so we can grab the error messages
             ResponseEntity<IetfRestconfErrorResponse> errorResponse = restTemplate.postForEntity(restPath, requestEntity, IetfRestconfErrorResponse.class);
             if (errorResponse.getBody() != null) {
                 for (IetfRestconfErrorResponse.IetfError error : errorResponse.getBody().getErrors().getErrorList()) {

--- a/backend/src/main/java/net/es/oscars/sb/nso/rest/NsoResponseErrorHandler.java
+++ b/backend/src/main/java/net/es/oscars/sb/nso/rest/NsoResponseErrorHandler.java
@@ -2,9 +2,11 @@ package net.es.oscars.sb.nso.rest;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.StreamUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 
 
 @Slf4j
@@ -20,11 +22,13 @@ public class NsoResponseErrorHandler implements ResponseErrorHandler {
     public void handleError(ClientHttpResponse httpResponse) throws IOException {
         // just log stuff
         if (httpResponse.getStatusCode().is5xxServerError()) {
-            log.error("server error status text: " +httpResponse.getStatusText());
-            log.error("server error body: " +httpResponse.getBody());
+            log.error("server error status text: {}", httpResponse.getStatusText());
         } else if (httpResponse.getStatusCode().is4xxClientError()) {
-            log.error("client error status text: " +httpResponse.getStatusText());
-            log.error("client error body: " +httpResponse.getBody());
+            log.error("client error status text: {}", httpResponse.getStatusText());
         }
+        // if we actually read the error body out the InputStream closes, so don't do the next line
+        // String body = StreamUtils.copyToString(httpResponse.getBody(), Charset.defaultCharset());
+        // log.error("error body: \n" +body);
+
     }
 }

--- a/backend/src/test/java/net/es/oscars/AbstractBackendTest.java
+++ b/backend/src/test/java/net/es/oscars/AbstractBackendTest.java
@@ -9,7 +9,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = BackendTestConfiguration.class)
+@SpringBootTest(classes = BackendTestConfiguration.class, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @TestPropertySource(locations = "classpath:testing.properties")
 @ActiveProfiles(profiles = "test")
 

--- a/backend/src/test/java/net/es/oscars/cuke/NsoProxySteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/NsoProxySteps.java
@@ -1,50 +1,19 @@
 package net.es.oscars.cuke;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.cucumber.java.Before;
-import io.cucumber.java.After;
-import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import io.opentelemetry.api.OpenTelemetry;
 import lombok.extern.slf4j.Slf4j;
-import net.es.oscars.app.props.NsoProperties;
-import net.es.oscars.app.props.StartupProperties;
 import net.es.oscars.ctg.UnitTests;
 import net.es.oscars.sb.nso.LiveStatusOperationalStateCacheManager;
 import net.es.oscars.sb.nso.NsoProxy;
 import net.es.oscars.sb.nso.rest.*;
-import net.es.oscars.web.beans.LiveStatusResponse;
-import net.es.topo.common.dto.nso.IetfRestconfErrorResponse;
-import org.apache.logging.log4j.util.Strings;
 import org.junit.experimental.categories.Category;
 
-import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
-import org.springframework.http.*;
-import org.springframework.util.FileCopyUtils;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 
-import java.io.*;
-import java.nio.file.Files;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @Slf4j
 @Category({UnitTests.class})
@@ -69,7 +38,7 @@ public class NsoProxySteps extends CucumberSteps {
     public void theGetLiveStatusShowMethodIsCalledWithDeviceAndArguments(String arg0, String arg1) {
         LiveStatusRequest liveStatusRequest = new LiveStatusRequest(arg0, arg1);
         liveStatus = proxy.getLiveStatusShow(liveStatusRequest);
-        log.info(liveStatus);
+        // log.info(liveStatus);
     }
 
     @Then("The resulting esnet-status response is not empty")
@@ -133,14 +102,6 @@ public class NsoProxySteps extends CucumberSteps {
     @Then("The resulting esnet-status response is empty")
     public void theResultingEsnetStatusResponseIsEmpty() {
         assert liveStatus.isEmpty();
-    }
-
-    public static String asString(Resource resource) {
-        try (Reader reader = new InputStreamReader(resource.getInputStream(), UTF_8)) {
-            return FileCopyUtils.copyToString(reader);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 
 }

--- a/backend/src/test/java/net/es/oscars/nso/NsoHttpServer.java
+++ b/backend/src/test/java/net/es/oscars/nso/NsoHttpServer.java
@@ -1,0 +1,108 @@
+
+package net.es.oscars.nso;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import net.es.oscars.sb.nso.rest.LiveStatusRequest;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.embedded.jetty.JettyServerCustomizer;
+import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+@Component
+@Slf4j
+public class NsoHttpServer {
+
+    @Value("${nso.mockPort}")
+    private int port;
+
+    @Bean
+    public ServletRegistrationBean<Servlet> servletRegistrationBean(){
+        return new ServletRegistrationBean<>(new NsoServlet(),"/restconf/data/esnet-status:esnet-status/nokia-show");
+    }
+
+    @Bean
+    public JettyServletWebServerFactory jettyCustomizer() {
+        JettyServletWebServerFactory jetty = new JettyServletWebServerFactory();
+        jetty.addServerCustomizers(new JettyCustomizer(port));
+        return jetty;
+    }
+
+    static class JettyCustomizer implements JettyServerCustomizer {
+
+        private final int port;
+
+        public JettyCustomizer(int port) {
+            this.port = port;
+        }
+
+        @Override
+        public void customize(Server server) {
+            ServerConnector connector = new ServerConnector(server);
+            connector.setPort(port);
+            server.addConnector(connector);
+            try {
+                connector.start();
+            } catch (Exception ex) {
+                throw new IllegalStateException("Failed to start Jetty connector", ex);
+            }
+        }
+    }
+
+    public static class NsoServlet extends HttpServlet {
+
+        @Override
+        protected void doPost(HttpServletRequest request, HttpServletResponse response)
+                throws ServletException, IOException {
+
+            StringBuilder payload = new StringBuilder();
+            try(BufferedReader reader = request.getReader()){
+                String line;
+                while ((line = reader.readLine()) != null){
+                    payload.append(line);
+                }
+            }
+            // consume the incoming LiveStatusRequest
+            LiveStatusRequest lsr = new ObjectMapper().readValue(payload.toString(), LiveStatusRequest.class);
+
+            response.setContentType("application/yang-data+json");
+
+            // read in the JSON that specifies how we respond to a particular (device, args) tuple
+            ResponseSpec[] responseSpecs = new ObjectMapper()
+                    .readValue(new ClassPathResource("http/response-specs.json").getFile(), ResponseSpec[].class);
+
+            // walk through the response specifications
+            for (ResponseSpec responseSpec : responseSpecs) {
+                // if the spec matches the request...
+                if (responseSpec.device.equals(lsr.getDevice()) && responseSpec.args.equals(lsr.getArgs())) {
+                    // read in the body from the file found in the path in the responseSpec...
+                    InputStream bodyInputStream = new ClassPathResource(responseSpec.body).getInputStream();
+                    String body = StreamUtils.copyToString(bodyInputStream, Charset.defaultCharset());
+                    // ... then write it out as our response
+                    response.getWriter().write(body);
+
+                    response.setStatus(responseSpec.status);
+                    return;
+                }
+            }
+
+        }
+    }
+
+    public record ResponseSpec(String device, String args, String body, Integer status) {}
+}

--- a/backend/src/test/resources/http/response-specs.json
+++ b/backend/src/test/resources/http/response-specs.json
@@ -1,0 +1,44 @@
+[
+  {
+    "device": "loc1-cr6",
+    "args": "router mpls lsp",
+    "body": "http/nso.esnet-status.nokia-show.router-mpls-lsp.response.json",
+    "status": 200
+  },
+  {
+    "device": "loc1-cr6",
+    "args": "service id 7115 sdp",
+    "body": "http/nso.esnet-status.nokia-show.service-sdp.response.json",
+    "status": 200
+  },
+  {
+    "device": "loc1-cr6",
+    "args": "service id 7115 sap",
+    "body": "http/nso.esnet-status.nokia-show.service-sap.response.json",
+    "status": 200
+  },
+  {
+    "device": "loc1-cr6",
+    "args": "service fdb-info",
+    "body": "http/nso.esnet-status.nokia-show.service-fdb-info.response.json",
+    "status": 200
+  },
+  {
+    "device": "loc1-cr6",
+    "args": "service id 7093 fdb detail",
+    "body": "http/nso.esnet-status.nokia-show.service-fdb-detail.response.json",
+    "status": 200
+  },
+  {
+    "device": "loc1-cr6",
+    "args": "service id 1111 sdp",
+    "body": "http/nso.esnet-status.nokia.empty.response.json",
+    "status": 200
+  },
+  {
+    "device": "does-not-exist-cr123",
+    "args": "service fdb-info",
+    "body": "http/nso.esnet-status.nokia.missing-device.response.json",
+    "status": 400
+  }
+]

--- a/backend/src/test/resources/testing.properties
+++ b/backend/src/test/resources/testing.properties
@@ -57,6 +57,8 @@ nso.backoff-milliseconds=30000
 
 nso.mock-live-show-commands=false
 nso.routing-domain=esnet-293
+# mock port used by jetty pretending to be NSO
+nso.mockPort=8080
 
 proc.timeout-held-after=300
 


### PR DESCRIPTION
### Description

modifies NSO proxy code calling NSO `esnet-status` service to correctly handle deserialization of different return values. 
### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
