### PR TITLE
fix: [REQUEST-127] Hot fix to support HTTP compression (GZIP) …

### DIFF
--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -31,6 +31,12 @@ server.port=${OSCARS_BACKEND_WEB_PORT}
 server.ssl.enabled=false
 server.servlet-path=/
 
+# Enable gzip compression BEGIN
+server.compression.enabled=true
+server.compression.min-response-size=1024
+server.compression.mime-types=application/octet-stream
+# Enable gzip compression END
+
 startup.banner=Welcome to OSCARS
 startup.exit=false
 
@@ -190,3 +196,6 @@ features.untagged-ports=false
 # Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation.QINQ enum type.
 # Disabled: Ingest Port objects and IGNORE the ethernetEncapsulation.QINQ enum type.
 features.qinq-ports=false
+
+# Support for HTTP compression (gzip) in net.es.oscars.soap.ClientUtil createRequestorClient() method
+client-util.enable-gzip-compression=true

--- a/backend/src/main/java/net/es/oscars/app/props/ClientUtilProperties.java
+++ b/backend/src/main/java/net/es/oscars/app/props/ClientUtilProperties.java
@@ -1,0 +1,14 @@
+package net.es.oscars.app.props;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties(prefix = "client-util")
+@Data
+@Component
+@NoArgsConstructor
+public class ClientUtilProperties {
+    public boolean enableGzipCompression = false;
+}

--- a/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
+++ b/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
@@ -32,8 +32,8 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import javax.xml.ws.handler.MessageContext;
 
 @Slf4j
 @Component
@@ -99,6 +99,12 @@ public class ClientUtil {
         // withGzipCompression argument is true.
         if (clientUtilProps.enableGzipCompression || withGzipCompression) {
             log.debug("ClientUtil.createRequesterClient() - Gzip compression enabled");
+            Map<String, Object> requestHeaders = new HashMap<>();
+            requestHeaders.put("Accept-Encoding", new ArrayList<>(List.of("gzip")));
+
+            // Ensure we sent the "Accept-Encoding: gzip" header to negotiate HTTP Compression
+            client.getRequestContext().put(MessageContext.HTTP_REQUEST_HEADERS, requestHeaders);
+            
             client.getInInterceptors().add(new GZIPInInterceptor());
             client.getOutInterceptors().add(new GZIPOutInterceptor());
         }

--- a/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
+++ b/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
@@ -6,6 +6,7 @@ import net.es.nsi.lib.soap.gen.nsi_2_0.services.point2point.ObjectFactory;
 import net.es.nsi.lib.soap.gen.nsi_2_0.connection.requester.ConnectionRequesterPort;
 import net.es.oscars.app.exc.NsiException;
 import net.es.oscars.app.props.NsiProperties;
+import net.es.oscars.app.props.ClientUtilProperties;
 import net.es.oscars.nsi.beans.NsiErrors;
 import net.es.oscars.nsi.ent.NsiRequesterNSA;
 import org.apache.cxf.configuration.jsse.TLSClientParameters;
@@ -13,6 +14,7 @@ import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.ext.logging.LoggingFeature;
 import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
+import org.apache.cxf.transport.common.gzip.GZIPInInterceptor;
 import org.apache.cxf.transport.http.HTTPConduit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -39,6 +41,9 @@ public class ClientUtil {
     @Autowired
     private NsiProperties nsiProps;
 
+    @Autowired
+    private ClientUtilProperties clientUtilProps;
+
     HashMap<String, ConnectionRequesterPort> requesterPorts = new HashMap<String, ConnectionRequesterPort>();
 
 
@@ -49,6 +54,18 @@ public class ClientUtil {
      * @return the ConnectionRequesterPort that you can use at the client
      */
     public ConnectionRequesterPort createRequesterClient(NsiRequesterNSA requesterNSA) throws NsiException {
+        // if withGzipCompression is not set, default to application.properties setting for
+        // client-util.enable-gzip-compression flag.
+        return createRequesterClient(requesterNSA, false);
+    }
+    /**
+     * Creates a client for interacting with an NSA requester
+     *
+     * @param requesterNSA the details of the requester to contact
+*
+     * @return the ConnectionRequesterPort that you can use at the client
+     */
+    public ConnectionRequesterPort createRequesterClient(NsiRequesterNSA requesterNSA, boolean withGzipCompression) throws NsiException {
         if (this.requesterPorts.containsKey(requesterNSA.getCallbackUrl())) {
             return this.requesterPorts.get(requesterNSA.getCallbackUrl());
         }
@@ -74,6 +91,17 @@ public class ClientUtil {
 
         ConnectionRequesterPort port = (ConnectionRequesterPort) fb.create();
         Client client = ClientProxy.getClient(port);
+
+        // Enable GZIP compression with appropriate headers in JaxWs Client if
+        // client-util.enable-gzip-compression=true
+        // or
+        // withGzipCompression argument is true.
+        if (clientUtilProps.enableGzipCompression || withGzipCompression) {
+            log.debug("ClientUtil.createRequesterClient() - Gzip compression enabled");
+            client.getInInterceptors().add(new GZIPInInterceptor());
+            client.getOutInterceptors().add(new GZIPInInterceptor());
+        }
+
         this.configureConduit(client, requesterNSA);
 
         this.requesterPorts.put(requesterNSA.getCallbackUrl(), port);

--- a/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
+++ b/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
@@ -15,6 +15,7 @@ import org.apache.cxf.ext.logging.LoggingFeature;
 import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
 import org.apache.cxf.transport.common.gzip.GZIPInInterceptor;
+import org.apache.cxf.transport.common.gzip.GZIPOutInterceptor;
 import org.apache.cxf.transport.http.HTTPConduit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -99,7 +100,7 @@ public class ClientUtil {
         if (clientUtilProps.enableGzipCompression || withGzipCompression) {
             log.debug("ClientUtil.createRequesterClient() - Gzip compression enabled");
             client.getInInterceptors().add(new GZIPInInterceptor());
-            client.getOutInterceptors().add(new GZIPInInterceptor());
+            client.getOutInterceptors().add(new GZIPOutInterceptor());
         }
 
         this.configureConduit(client, requesterNSA);

--- a/backend/src/main/java/net/es/oscars/web/rest/HoldController.java
+++ b/backend/src/main/java/net/es/oscars/web/rest/HoldController.java
@@ -87,6 +87,7 @@ public class HoldController {
 
         connLock.lock();
         try {
+            log.info("attempt to extend hold on connection " + connectionId);
             Optional<Connection> maybeConnection = connRepo.findByConnectionId(connectionId);
             if (maybeConnection.isPresent()) {
                 Connection conn = maybeConnection.get();
@@ -97,7 +98,7 @@ public class HoldController {
                     log.debug("pretending to extend hold for a non-HELD connection");
                 }
             } else {
-                throw new NoSuchElementException("connection not found");
+                throw new NoSuchElementException("connection " + connectionId + " not found");
             }
 
         } finally {


### PR DESCRIPTION
Update to  ClientUtil.createRequesterClient() method, which uses JaxWx Client object to call HTTP POST

Added optional configuration that enables HTTP compression (Gzip) with the JaxWx Client object within ClientUtil.createRequestorClient(). Can set `client-util.enable-gzip-compression=true` in application.properties or pass optional secondary argument `boolean withGzipCompression` as `true` when calling `ClientUtil.createRequestorClient()` method.

NOTE, we are also adding the following to application.properties, but I am unsure if these actually enable HTTP compression within the built-in server. May need help testing this out.

```
# Enable gzip compression BEGIN
server.compression.enabled=true
server.compression.min-response-size=1024
server.compression.mime-types=application/octet-stream
# Enable gzip compression END
```



### Description

**INCLUDE PR DESCRIPTION**

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [ ] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
