### PR TITLE
fix: [OS-445] modify which ARCHIVED connections get returned

### DIFF
--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
@@ -749,9 +749,9 @@ public class NsiService {
         }
         Connection c = mc.get();
         if (c.getPhase().equals(Phase.ARCHIVED)) {
-            // if this is archived and the end date was 24 hours ago or more, don't return it
-            if (c.getArchived().getSchedule()
-                    .getEnding().isBefore(Instant.now().minus(24L, ChronoUnit.HOURS))) {
+            // if this is archived return it only the last modified date was 24 hours ago or less
+            int yesterday = (int) Instant.now().minus(24L, ChronoUnit.HOURS).getEpochSecond();
+            if (c.getLast_modified() > yesterday) {
                 return null;
             }
         }


### PR DESCRIPTION
### Description

Before: we returned any connections that had ending date from 24h ago until forever; since many connections set a  expiry day far into the future this resulted in a lot of connections being returned, most of them probably irrelevant

Now: we return only the connections that were modified in the last 24 hours; this gives a chance for the ones that recently expire to be returned while hopefully not hitting the message limit. 

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [ ] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
