### PR TITLE
refactor: [OS-448] Avoid extra HTTP POST calls in NsoProxy getLiveStatusShow()

### DIFF
--- a/backend/src/main/java/net/es/oscars/sb/nso/NsoProxy.java
+++ b/backend/src/main/java/net/es/oscars/sb/nso/NsoProxy.java
@@ -20,6 +20,7 @@ import net.es.oscars.sb.nso.rest.NsoServicesWrapper;
 import net.es.oscars.sb.nso.rest.LiveStatusRequest;
 import net.es.oscars.sb.nso.rest.LiveStatusMockData;
 import net.es.oscars.sb.nso.rest.LiveStatusOutput;
+import net.es.oscars.web.beans.LiveStatusResponse;
 import net.es.topo.common.devel.DevelUtils;
 import net.es.topo.common.dto.nso.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,9 +38,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Slf4j
 @Component
@@ -424,26 +423,69 @@ public class NsoProxy {
         errorStr.append("esnet-status error\n");
         final HttpEntity<LiveStatusRequest> requestEntity = new HttpEntity<>(liveStatusRequest);
         // first, try to get a LiveStatusOutput
+        ResponseEntity<Object> responseEntity = null;
         try {
-            ResponseEntity<LiveStatusOutput> responseEntity = restTemplate.postForEntity(restPath, requestEntity, LiveStatusOutput.class);
+            responseEntity = restTemplate.postForEntity(restPath, requestEntity, Object.class);
+            if (responseEntity.getStatusCode() != HttpStatus.OK) {
+                if (responseEntity.getStatusCode() == HttpStatus.BAD_REQUEST) {
+                    throw new RestClientException("Bad request reported by server. Processing error message:\n" + responseEntity.getBody());
+                } else {
+                    throw new Exception("URL " + restPath + ". Unexpected response code: " + responseEntity.getStatusCode() + ", body:\n" + responseEntity.getBody().toString());
+                }
+            }
             if (responseEntity.getBody() != null) {
-                return responseEntity.getBody().getOutput();
+                // Attempt to deserialize as LiveStatusOutput
+                // or
+                // Attempt to deserialize as IetfRestconfErrorResponse
+                try {
+
+                    ObjectMapper mapper = new ObjectMapper();
+                    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+                    LinkedHashMap<String, String> body = ((LinkedHashMap<String, String>) responseEntity.getBody());
+
+                    String json = mapper.writeValueAsString(body);
+
+                    if (body.containsKey("esnet-status:output")) {
+                        LiveStatusOutput liveOutput = mapper.readValue(json, LiveStatusOutput.class);
+
+                        return liveOutput.getOutput();
+                    } else {
+                        // Cannot figure out what this is.
+                        throw new Exception("Unknown body content received. Cannot deserialize as LiveStatusOutput or IetfRestconfErrorResponse:\n" + json);
+                    }
+
+                } catch (Exception e) {
+                    // Unknown exception
+                    log.error("NsoProxy.getLiveStatusShow() - Error while attempting to process response for LiveStatusOutput:\n" + e.getMessage());
+                }
+
             } else {
                 errorStr.append("null response body\n");
             }
-        } catch (RestClientException ex) {
-            // if we get an exception, the underlying exception could be a HttpMessageNotReadableException
-            // because the actual response is an IetfRestconfErrorResponse
+        } catch (RestClientException re) {
+            try {
+                if (responseEntity != null) {
+                    ObjectMapper mapper = new ObjectMapper();
+                    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+                    LinkedHashMap<String, String> body = ((LinkedHashMap<String, String>) responseEntity.getBody());
 
-            // we try again, but this time, try to deserialize into that class so we can grab the error messages
-            ResponseEntity<IetfRestconfErrorResponse> errorResponse = restTemplate.postForEntity(restPath, requestEntity, IetfRestconfErrorResponse.class);
-            if (errorResponse.getBody() != null) {
-                for (IetfRestconfErrorResponse.IetfError error : errorResponse.getBody().getErrors().getErrorList()) {
-                    errorStr.append(error.getErrorMessage()).append("\n");
+                    String json = mapper.writeValueAsString(body);
+
+                    if (body.containsKey("ietf-restconf:errors")) {
+                        IetfRestconfErrorResponse ietfError = mapper.readValue(json, IetfRestconfErrorResponse.class);
+                        for (IetfRestconfErrorResponse.IetfError error : ietfError.getErrors().getErrorList()) {
+                            errorStr.append(error.getErrorMessage()).append("\n");
+                        }
+                    } else {
+                        throw new Exception("NsoProxy.getLiveStatusShow() - Error while attempting to process response for IetfRestconfErrorResponse:\n" + json);
+                    }
                 }
-            } else {
-                errorStr.append("null error body\n");
+            } catch (Exception e) {
+                log.error(e.getLocalizedMessage(), e);
             }
+        } catch (Exception e) {
+            // Not something we can deserialize.
+            log.error(e.getLocalizedMessage(), e);
         }
 
         return errorStr.toString();

--- a/backend/src/main/java/net/es/oscars/sb/nso/rest/LiveStatusOutput.java
+++ b/backend/src/main/java/net/es/oscars/sb/nso/rest/LiveStatusOutput.java
@@ -21,8 +21,8 @@ public class LiveStatusOutput {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    private static class WrappedOutput {
-        private String result;
+    public static class WrappedOutput {
+        public String result;
     }
 
     public String getOutput() {

--- a/backend/src/test/java/net/es/oscars/cuke/NsoProxySteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/NsoProxySteps.java
@@ -35,7 +35,7 @@ public class NsoProxySteps extends CucumberSteps {
     ArrayList<LiveStatusLspResult> lspResults;
 
     @When("^The getLiveStatusShow method is called with device \"([^\"]*)\" and arguments \"([^\"]*)\"$")
-    public void theGetLiveStatusShowMethodIsCalledWithDeviceAndArguments(String arg0, String arg1) {
+    public void theGetLiveStatusShowMethodIsCalledWithDeviceAndArguments(String arg0, String arg1) throws Throwable {
         LiveStatusRequest liveStatusRequest = new LiveStatusRequest(arg0, arg1);
         liveStatus = proxy.getLiveStatusShow(liveStatusRequest);
         // log.info(liveStatus);

--- a/backend/src/test/java/net/es/oscars/nso/NsoHttpServer.java
+++ b/backend/src/test/java/net/es/oscars/nso/NsoHttpServer.java
@@ -3,11 +3,13 @@ package net.es.oscars.nso;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.sb.nso.rest.LiveStatusRequest;
+import org.eclipse.jetty.ee10.webapp.Configuration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,12 +30,17 @@ import java.nio.charset.Charset;
 @Slf4j
 public class NsoHttpServer {
 
-    @Value("${nso.mockPort}")
+    @Value(value = "${nso.mockPort}")
     private int port;
 
     @Bean
     public ServletRegistrationBean<Servlet> servletRegistrationBean(){
-        return new ServletRegistrationBean<>(new NsoServlet(),"/restconf/data/esnet-status:esnet-status/nokia-show");
+        NsoServlet servlet = new NsoServlet();
+
+        return new ServletRegistrationBean<>(
+                servlet,
+                "/restconf/data/esnet-status:esnet-status/nokia-show"
+        );
     }
 
     @Bean
@@ -67,9 +74,10 @@ public class NsoHttpServer {
     public static class NsoServlet extends HttpServlet {
 
         @Override
-        protected void doPost(HttpServletRequest request, HttpServletResponse response)
-                throws ServletException, IOException {
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {}
 
+        @Override
+        protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
             StringBuilder payload = new StringBuilder();
             try(BufferedReader reader = request.getReader()){
                 String line;
@@ -97,7 +105,7 @@ public class NsoHttpServer {
                     response.getWriter().write(body);
 
                     response.setStatus(responseSpec.status);
-                    return;
+                    break;
                 }
             }
 


### PR DESCRIPTION

### Description

We can avoid the extra HTTP POST call. I propose we first get the payload, and then attempt to deserialize to the appropriate class object type.

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [ ] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [ ] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
