### PR TITLE
fix: [OS-445] Fix gzip compression in ClientUtil

### DIFF
--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -199,3 +199,8 @@ features.qinq-ports=false
 
 # Support for HTTP compression (gzip) in net.es.oscars.soap.ClientUtil createRequestorClient() method
 client-util.enable-gzip-compression=true
+# Force gzip (yes if true)
+client-util.force-gzip=true
+# The minimum threshold size to apply gzip compression. 0 for any size.
+client-util.gzip-threshold=0
+client-util.gzip-content-types=application/xml,text/xml

--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -34,7 +34,7 @@ server.servlet-path=/
 # Enable gzip compression BEGIN
 server.compression.enabled=true
 server.compression.min-response-size=1024
-server.compression.mime-types=application/octet-stream
+server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/octet-stream
 # Enable gzip compression END
 
 startup.banner=Welcome to OSCARS
@@ -190,7 +190,7 @@ esdb.vlan-sync-period=PT5M
 # Process untagged 'NULL' ethernet encapsulation ports from topology discovery:
 # Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation.NULL enum type.
 # Disabled: Ingest Port objects and IGNORE the ethernetEncapsulation.NULL enum type.
-features.untagged-ports=false
+features.untagged-ports=true
 
 # Process QINQ ethernet encapsulation ports from topology discovery:
 # Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation.QINQ enum type.

--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -34,7 +34,7 @@ server.servlet-path=/
 # Enable gzip compression BEGIN
 server.compression.enabled=true
 server.compression.min-response-size=1024
-server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/octet-stream
+server.compression.mime-types=application/xml,text/xml,text/plain,application/octet-stream
 # Enable gzip compression END
 
 startup.banner=Welcome to OSCARS
@@ -190,7 +190,7 @@ esdb.vlan-sync-period=PT5M
 # Process untagged 'NULL' ethernet encapsulation ports from topology discovery:
 # Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation.NULL enum type.
 # Disabled: Ingest Port objects and IGNORE the ethernetEncapsulation.NULL enum type.
-features.untagged-ports=true
+features.untagged-ports=false
 
 # Process QINQ ethernet encapsulation ports from topology discovery:
 # Enabled: Ingest Port objects and INCLUDE the ethernetEncapsulation.QINQ enum type.

--- a/backend/src/main/java/net/es/oscars/app/props/ClientUtilProperties.java
+++ b/backend/src/main/java/net/es/oscars/app/props/ClientUtilProperties.java
@@ -2,8 +2,13 @@ package net.es.oscars.app.props;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @ConfigurationProperties(prefix = "client-util")
 @Data
@@ -11,4 +16,12 @@ import org.springframework.stereotype.Component;
 @NoArgsConstructor
 public class ClientUtilProperties {
     public boolean enableGzipCompression = false;
+    public boolean forceGzip = false;
+    public int gzipThreshold = 0;
+    // Comma separated content types
+    public String gzipContentTypes = "application/xml";
+
+    public List<String> getContentTypes() {
+        return Arrays.asList(gzipContentTypes.split(","));
+    }
 }

--- a/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
+++ b/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
@@ -99,21 +99,19 @@ public class ClientUtil {
         // withGzipCompression argument is true.
         if (clientUtilProps.enableGzipCompression || withGzipCompression) {
             log.info("ClientUtil.createRequesterClient() - Gzip compression enabled");
-//            Map<String, Object> requestHeaders = new HashMap<>();
-//            requestHeaders.put("Accept-Encoding", new ArrayList<>(List.of("gzip")));
-
-            // Ensure we sent the "Accept-Encoding: gzip" header to negotiate HTTP Compression
-//            client.getRequestContext().put(MessageContext.HTTP_REQUEST_HEADERS, requestHeaders);
             GZIPOutInterceptor gzipOutInterceptor = new GZIPOutInterceptor();
-
             GZIPInInterceptor gzipInInterceptor = new GZIPInInterceptor();
-            
-            gzipOutInterceptor.setForce(true);
-            gzipOutInterceptor.setThreshold(0); // force on all messages
-            Set<String> contentTypes = new HashSet<>();
 
-            contentTypes.add("application/xml");
+            // force on all messages regardless of size?
+            log.info("ClientUtil.createRequesterClient() - force is " + clientUtilProps.forceGzip);
+            log.info("ClientUtil.createRequesterClient() - threshold is " + clientUtilProps.gzipThreshold);
 
+            gzipOutInterceptor.setForce(clientUtilProps.forceGzip);
+            gzipOutInterceptor.setThreshold(clientUtilProps.gzipThreshold);
+
+            List<String> types = clientUtilProps.getContentTypes();
+            Set<String> contentTypes = new HashSet<>(types);
+            log.info("ClientUtil.createRequesterClient() - Gzip compression will be enabled for " + contentTypes.toString());
             gzipOutInterceptor.setSupportedPayloadContentTypes(contentTypes);
 
             client.getInInterceptors().add(gzipInInterceptor);

--- a/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
+++ b/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
@@ -109,7 +109,7 @@ public class ClientUtil {
             GZIPInInterceptor gzipInInterceptor = new GZIPInInterceptor();
             
             gzipOutInterceptor.setForce(true);
-            gzipOutInterceptor.setThreshold(7);
+            gzipOutInterceptor.setThreshold(0); // force on all messages
             Set<String> contentTypes = new HashSet<>();
 
             contentTypes.add("application/xml");

--- a/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
+++ b/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
@@ -99,14 +99,20 @@ public class ClientUtil {
         // withGzipCompression argument is true.
         if (clientUtilProps.enableGzipCompression || withGzipCompression) {
             log.debug("ClientUtil.createRequesterClient() - Gzip compression enabled");
-            Map<String, Object> requestHeaders = new HashMap<>();
-            requestHeaders.put("Accept-Encoding", new ArrayList<>(List.of("gzip")));
+//            Map<String, Object> requestHeaders = new HashMap<>();
+//            requestHeaders.put("Accept-Encoding", new ArrayList<>(List.of("gzip")));
 
             // Ensure we sent the "Accept-Encoding: gzip" header to negotiate HTTP Compression
-            client.getRequestContext().put(MessageContext.HTTP_REQUEST_HEADERS, requestHeaders);
+//            client.getRequestContext().put(MessageContext.HTTP_REQUEST_HEADERS, requestHeaders);
+            GZIPOutInterceptor gzipOutInterceptor = new GZIPOutInterceptor();
+
+            GZIPInInterceptor gzipInInterceptor = new GZIPInInterceptor();
             
-            client.getInInterceptors().add(new GZIPInInterceptor());
-            client.getOutInterceptors().add(new GZIPOutInterceptor());
+            gzipOutInterceptor.setForce(true);
+            gzipOutInterceptor.setThreshold(7);
+
+            client.getInInterceptors().add(gzipInInterceptor);
+            client.getOutInterceptors().add(gzipOutInterceptor);
         }
 
         this.configureConduit(client, requesterNSA);

--- a/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
+++ b/backend/src/main/java/net/es/oscars/soap/ClientUtil.java
@@ -98,7 +98,7 @@ public class ClientUtil {
         // or
         // withGzipCompression argument is true.
         if (clientUtilProps.enableGzipCompression || withGzipCompression) {
-            log.debug("ClientUtil.createRequesterClient() - Gzip compression enabled");
+            log.info("ClientUtil.createRequesterClient() - Gzip compression enabled");
 //            Map<String, Object> requestHeaders = new HashMap<>();
 //            requestHeaders.put("Accept-Encoding", new ArrayList<>(List.of("gzip")));
 
@@ -110,9 +110,16 @@ public class ClientUtil {
             
             gzipOutInterceptor.setForce(true);
             gzipOutInterceptor.setThreshold(7);
+            Set<String> contentTypes = new HashSet<>();
+
+            contentTypes.add("application/xml");
+
+            gzipOutInterceptor.setSupportedPayloadContentTypes(contentTypes);
 
             client.getInInterceptors().add(gzipInInterceptor);
             client.getOutInterceptors().add(gzipOutInterceptor);
+        } else {
+            log.info("ClientUtil.createRequesterClient() - Gzip compression disabled");
         }
 
         this.configureConduit(client, requesterNSA);


### PR DESCRIPTION
### Description

Updates ClientUtil gzip compression enable/disable to also include text/xml mime-type as a supported payload content type for the Gzip Out Interceptor.

Work related to OS-445 troubleshooting.

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [ ] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
