### PR TITLE
fix: [OS-454] Logging fails to commit transaction, duplicate key error

### DIFF
--- a/backend/src/main/java/net/es/oscars/resv/ent/EventLog.java
+++ b/backend/src/main/java/net/es/oscars/resv/ent/EventLog.java
@@ -2,6 +2,7 @@ package net.es.oscars.resv.ent;
 
 import com.fasterxml.jackson.annotation.*;
 import jakarta.persistence.*;
+import jakarta.transaction.Transactional;
 import lombok.*;
 import org.hibernate.proxy.HibernateProxy;
 
@@ -14,6 +15,7 @@ import java.util.Objects;
 @ToString
 @RequiredArgsConstructor
 @Entity
+@Transactional
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/backend/src/main/java/net/es/oscars/sb/nso/rest/NsoResponseErrorHandler.java
+++ b/backend/src/main/java/net/es/oscars/sb/nso/rest/NsoResponseErrorHandler.java
@@ -1,11 +1,13 @@
 package net.es.oscars.sb.nso.rest;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.Charset;
 
 
@@ -17,14 +19,14 @@ public class NsoResponseErrorHandler implements ResponseErrorHandler {
 
         return (httpResponse.getStatusCode().is4xxClientError()  || httpResponse.getStatusCode().is5xxServerError());
     }
-
     @Override
-    public void handleError(ClientHttpResponse httpResponse) throws IOException {
+    public void handleError(URI url, HttpMethod method, ClientHttpResponse httpResponse) throws IOException {
         // just log stuff
+        log.error("NsoResponseErrorHandler: Error handling " + url + " " + method + " " + httpResponse.getStatusCode());
         if (httpResponse.getStatusCode().is5xxServerError()) {
-            log.error("server error status text: {}", httpResponse.getStatusText());
+            log.error("...server error status text: {}", httpResponse.getStatusText());
         } else if (httpResponse.getStatusCode().is4xxClientError()) {
-            log.error("client error status text: {}", httpResponse.getStatusText());
+            log.error("...client error status text: {}", httpResponse.getStatusText());
         }
         // if we actually read the error body out the InputStream closes, so don't do the next line
         // String body = StreamUtils.copyToString(httpResponse.getBody(), Charset.defaultCharset());


### PR DESCRIPTION
A potential race condition is causing a duplicate event_log_pkey error in the database transaction. Adding @Transactional to EventLog. Also updating the NsoResponseErrorHandler handleError() method overrride signature, as the original signature is marked as deprecated. Also updating what we log to include the URL and HTTP Method in NsoResponseErrorHandler.handleError()

### Description

**INCLUDE PR DESCRIPTION**

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [ ] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
