### PR TITLE
fix: [OS-505] only add criteria to query result when underlying connection is reserved

### DIFF
--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiQueries.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiQueries.java
@@ -183,7 +183,6 @@ public class NsiQueries {
         Optional<Connection> mc = nsiMappingService.getMaybeOscarsConnection(mapping);
         QuerySummaryResultType qsrt = new QuerySummaryResultType();
         qsrt.setConnectionId(mapping.getNsiConnectionId());
-        QuerySummaryResultCriteriaType qsrct = new QuerySummaryResultCriteriaType();
         String description;
         ConnectionStatesType cst;
         if (mc.isEmpty()) {
@@ -194,7 +193,6 @@ public class NsiQueries {
                 return null;
             }
             log.info("returning a placeholder for "+mapping.getNsiConnectionId());
-            qsrct.setSchedule(request.getIncoming().getCriteria().getSchedule());
             description = request.getIncoming().getDescription();
             cst = new ConnectionStatesType();
             cst.setProvisionState(mapping.getProvisionState());
@@ -224,20 +222,19 @@ public class NsiQueries {
             }
             description = c.getDescription();
 
+            QuerySummaryResultCriteriaType qsrct = new QuerySummaryResultCriteriaType();
             qsrct.setSchedule(nsiMappingService.oscarsToNsiSchedule(sch));
             Components cmp = getComponents(c);
             P2PServiceBaseType p2p = nsiMappingService.makeP2P(cmp, mapping);
-
             net.es.nsi.lib.soap.gen.nsi_2_0.services.point2point.ObjectFactory p2pof = new ObjectFactory();
             qsrct.getAny().add(p2pof.createP2Ps(p2p));
+            qsrct.setServiceType(NsiService.SERVICE_TYPE);
+            qsrct.setVersion(mapping.getDataplaneVersion());
+            qsrt.getCriteria().add(qsrct);
+
             cst = nsiMappingService.makeConnectionStates(mapping, c);
         }
 
-        qsrct.setServiceType(NsiService.SERVICE_TYPE);
-        qsrct.setVersion(mapping.getDataplaneVersion());
-
-
-        qsrt.getCriteria().add(qsrct);
 
         qsrt.setDescription(description);
         qsrt.setGlobalReservationId(mapping.getNsiGri());


### PR DESCRIPTION

### Description
follow the spec as per "...if the initial version of the reservation has not yet been committed, the query will return base reservation information (connectionId, globalReservationId, description, requesterNSA, and connectionStates) with no versioned reservation criteria."

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [x] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
