### PR TITLE
fix: [OS-510] improve NSI sync query behavior & logging

### DIFF
--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiHeaderUtils.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiHeaderUtils.java
@@ -38,7 +38,7 @@ public class NsiHeaderUtils {
 
     /* header processing */
 
-    public void processHeader(CommonHeaderType inHeader) throws NsiValidationException, NsiInternalException {
+    public void processHeader(CommonHeaderType inHeader, boolean updateRequester) throws NsiValidationException, NsiInternalException {
         String error = "";
         boolean hasError = false;
         if (!inHeader.getProviderNSA().equals(providerNsa)) {
@@ -59,7 +59,9 @@ public class NsiHeaderUtils {
         if (hasError) {
             throw new NsiValidationException(error, NsiErrors.SEC_ERROR);
         }
-        this.updateRequester(inHeader.getReplyTo(), inHeader.getRequesterNSA());
+        if (updateRequester) {
+            this.updateRequester(inHeader.getReplyTo(), inHeader.getRequesterNSA());
+        }
     }
 
     public void updateRequester(String replyTo, String nsaId) throws NsiInternalException {

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
@@ -844,6 +844,7 @@ public class NsiService {
                     .serviceId(null)
                     .pipes(pipes)
                     .tags(tags)
+                    .connection_mtu(9000)
                     .username("nsi")
                     .build();
             try {

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
@@ -516,6 +516,8 @@ public class NsiService {
             if (requesterNSA.getCallbackUrl().isEmpty()) {
                 log.info("empty callback url, unable to reserveTimeout");
                 return;
+            } else {
+                log.info("reserveTimeoutCallback, NSA {} url: {}", requesterNSA.getNsaId(), requesterNSA.getCallbackUrl());
             }
             ConnectionRequesterPort port = nsiSoapClientUtil.createRequesterClient(requesterNSA);
             String corrId = nsiHeaderUtils.newCorrelationId();
@@ -543,6 +545,8 @@ public class NsiService {
         if (requesterNSA.getCallbackUrl().isEmpty()) {
             log.info("empty callback url, unable to reserveConfirmCallback");
             return;
+        } else {
+            log.info("reserveConfirmCallback, NSA {} url: {}", requesterNSA.getNsaId(), requesterNSA.getCallbackUrl());
         }
 
         ConnectionRequesterPort port = nsiSoapClientUtil.createRequesterClient(requesterNSA);
@@ -604,7 +608,7 @@ public class NsiService {
     // used to notify when the dataplane version is updated
     public void dataplaneCallback(NsiMapping mapping, State st) {
         try {
-            log.info("dataplaneCallback ");
+            log.info("dataplaneCallback");
             String nsaId = mapping.getNsaId();
 
             int notificationId = nsiMappingService.nextNotificationId(mapping);
@@ -614,6 +618,8 @@ public class NsiService {
             if (requesterNSA.getCallbackUrl().isEmpty()) {
                 log.info("empty callback url, unable to dataplaneCallback");
                 return;
+            } else {
+                log.info("dataplaneCallback, NSA {} url: {}", requesterNSA.getNsaId(), requesterNSA.getCallbackUrl());
             }
 
             ConnectionRequesterPort port = nsiSoapClientUtil.createRequesterClient(requesterNSA);
@@ -653,6 +659,8 @@ public class NsiService {
             if (requesterNSA.getCallbackUrl().isEmpty()) {
                 log.info("empty callback url, unable to okCallback");
                 return;
+            } else {
+                log.info("okCallback, NSA {} url: {}", requesterNSA.getNsaId(), requesterNSA.getCallbackUrl());
             }
 
             ConnectionRequesterPort port = nsiSoapClientUtil.createRequesterClient(requesterNSA);
@@ -689,6 +697,8 @@ public class NsiService {
             if (requesterNSA.getCallbackUrl().isEmpty()) {
                 log.info("empty callback url, unable to errCallback");
                 return;
+            } else {
+                log.info("errCallback, NSA {} url: {}", requesterNSA.getNsaId(), requesterNSA.getCallbackUrl());
             }
 
             ConnectionRequesterPort port = nsiSoapClientUtil.createRequesterClient(requesterNSA);

--- a/backend/src/main/java/net/es/oscars/soap/NsiProvider.java
+++ b/backend/src/main/java/net/es/oscars/soap/NsiProvider.java
@@ -50,7 +50,7 @@ public class NsiProvider implements ConnectionProviderPort {
 
         try {
             // we process the header
-            nsiHeaderUtils.processHeader(header.value);
+            nsiHeaderUtils.processHeader(header.value, true);
         } catch (NsiException e) {
             String errMsg = e.getMessage();
             ServiceExceptionType sExcTpe = nsiHeaderUtils.makeSvcExcpType(e.getMessage(), e.getError(), new ArrayList<>(), reserve.getConnectionId());
@@ -119,7 +119,7 @@ public class NsiProvider implements ConnectionProviderPort {
             // then we check if it matches an NSI mapping; all our generic operations need to match
             nsiMappingService.getMapping(nsiConnectionId);
             // then we process the header
-            nsiHeaderUtils.processHeader(header.value);
+            nsiHeaderUtils.processHeader(header.value, true);
         } catch (NsiException e) {
             String errMsg = e.getMessage();
             ServiceExceptionType sExcTpe = nsiHeaderUtils.makeSvcExcpType(e.getMessage(), e.getError(), new ArrayList<>(), nsiConnectionId);
@@ -146,7 +146,9 @@ public class NsiProvider implements ConnectionProviderPort {
                                                       Holder<CommonHeaderType> header) throws Error {
         try {
             nsiQueries.validateQuery(query);
-            nsiHeaderUtils.processHeader(header.value);
+            // we do not want to update the requester callback URL when
+            // processing the header from this sync operation
+            nsiHeaderUtils.processHeader(header.value, false);
             log.info("starting sync QuerySummary");
             QuerySummaryConfirmedType qsct = nsiQueries.querySummary(query);
             nsiHeaderUtils.makeResponseHeader(header.value);
@@ -173,7 +175,7 @@ public class NsiProvider implements ConnectionProviderPort {
             // We validate the query
             nsiQueries.validateQuery(query);
             // then we process the header
-            nsiHeaderUtils.processHeader(header.value);
+            nsiHeaderUtils.processHeader(header.value, true);
         } catch (NsiException e) {
             String errMsg = e.getMessage();
             ServiceExceptionType sExcTpe = nsiHeaderUtils.makeSvcExcpType(e.getMessage(), e.getError(), new ArrayList<>(), "");


### PR DESCRIPTION
### Description
- consistently returns an nsiQuery result when in HELD 
- do not return NSI criteria for query unless in RESERVED
- adds param to processHeader() to conditionally update the NSA callback URL 
  - update callers to use new param; syncQuery uses `false` to prevent updates
- more detailed logging around callbacks 


