### PR TITLE
fix: [OS-516] speed up NSO resource reservation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,12 @@
 # OSCARS Release Notes
+### 1.2.28
+> June 2025
+- OS-499 NSI queryNotification() implementation
+- OS-495 holdConnection() and validation refactor
+- OS-505 NSI syncQuery() should not return p2p criteria before initial commit()
+- OS-510 improve NSI syncQuery()
+- OS-516 speed up commit()
+
 ### 1.2.27
 > May 2025
 - OS-496 logevent error

--- a/backend/src/main/java/net/es/oscars/sb/nso/resv/NsoResourceService.java
+++ b/backend/src/main/java/net/es/oscars/sb/nso/resv/NsoResourceService.java
@@ -7,9 +7,11 @@ import net.es.oscars.resv.db.ScheduleRepository;
 import net.es.oscars.resv.ent.Connection;
 import net.es.oscars.resv.ent.Schedule;
 import net.es.oscars.model.Interval;
+import net.es.oscars.sb.nso.ent.NsoVcId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.util.*;
 
 @Component
@@ -40,16 +42,41 @@ public class NsoResourceService {
 
     public void reserve(Connection conn) throws NsoResvException {
         log.info("starting NSO resource reservation");
-        Schedule sched = conn.getReserved().getSchedule();
-        Interval interval = Interval.builder()
-                .beginning(sched.getBeginning())
-                .ending(sched.getEnding())
-                .build();
-        List<Schedule> overlappingSchedules = scheduleRepo.findOverlapping(interval.getBeginning(), interval.getEnding());
+        Schedule connectionSchedule = conn.getReserved().getSchedule();
+
+        // we get all the NsoVcIds; every RESERVED connection should have one.
+        List<NsoVcId> allNsoVcIds = nsoVcIdService.allNsoVcIds();
+
+
+        List<Schedule> overlappingSchedules = new ArrayList<>();
+        for (NsoVcId nsoVcId : allNsoVcIds) {
+            // from there we can retrieve the schedule objects associated with each NsoVcId
+            scheduleRepo.findById(nsoVcId.getScheduleId()).ifPresent(nsoVcIdSchedule -> {
+                /*
+                 * evaluate each to see if it overlaps with the Schedule from the incoming Connection
+                 *
+                 * an interval A overlaps with another interval B if the following is true:
+                 *     max(A.beginning, B.beginning) <=  min(A.ending, B.ending)
+                 */
+                Instant maxBeginning = nsoVcIdSchedule.getBeginning();
+                if (connectionSchedule.getBeginning().isAfter(maxBeginning)) {
+                    maxBeginning = connectionSchedule.getBeginning();
+                }
+                Instant minEnding = nsoVcIdSchedule.getEnding();
+                if (connectionSchedule.getEnding().isBefore(minEnding)) {
+                    minEnding = connectionSchedule.getEnding();
+                }
+                if (maxBeginning.isBefore(minEnding)) {
+                    overlappingSchedules.add(nsoVcIdSchedule);
+                }
+            });
+        }
+
         nsoVcIdService.findAndReserveVcId(conn, overlappingSchedules);
         nsoQosSapPolicyIdService.findAndReserveQosSapPolicyIds(conn, overlappingSchedules);
         nsoSdpIdService.findAndReserveNsoSdpIds(conn, overlappingSchedules);
         nsoSdpVcIdService.findAndReserveNsoSdpVcIds(conn, overlappingSchedules);
+        log.info("starting NSO resource reservation");
 
     }
 

--- a/backend/src/main/java/net/es/oscars/sb/nso/resv/NsoVcIdService.java
+++ b/backend/src/main/java/net/es/oscars/sb/nso/resv/NsoVcIdService.java
@@ -32,6 +32,13 @@ public class NsoVcIdService {
         });
     }
 
+    @Transactional
+    public List<NsoVcId> allNsoVcIds() {
+        ArrayList<NsoVcId> result = new ArrayList<>();
+        nsoVcIdDAO.findAll().forEach(result::add);
+        return result;
+    }
+
 
     @Transactional
     public void findAndReserveVcId(Connection conn, List<Schedule> schedules) throws NsoResvException {


### PR DESCRIPTION
### Description

modifies the NSO resource reservation step to be significantly faster, eliminating unnecessary DB access

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
