### PR TITLE
refactor: [OS-489] esdb graphql

### DIFF
--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -187,6 +187,7 @@ nso.username=${NSO_USERNAME}
 nso.password=${NSO_PASSWORD}
 
 esdb.uri=${ESDB_URI}
+esdb.graphql-uri=${ESDB_GRAPHQL_URI}
 esdb.api-key=${ESDB_API_KEY}
 esdb.enabled=true
 # format this period like

--- a/backend/graphql.config.yml
+++ b/backend/graphql.config.yml
@@ -1,0 +1,4 @@
+schema:
+  - https://esdb.es.net/esdb_api/graphql
+  - ./src/main/resources/graphql/schema.graphql
+documents: './src/main/resources/graphql-documents/*.graphql'

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>net.es.topo.common</groupId>
             <artifactId>topo-common</artifactId>
-            <version>0.0.39</version>
+            <version>0.0.40</version>
         </dependency>
         <dependency>
             <groupId>net.es.nsi</groupId>

--- a/backend/src/main/java/net/es/oscars/app/props/EsdbProperties.java
+++ b/backend/src/main/java/net/es/oscars/app/props/EsdbProperties.java
@@ -19,7 +19,7 @@ public class EsdbProperties {
     private String uri;
 
     @NonNull
-    private String graphQlUri;
+    private String graphqlUri = "http://esdb:8080/esdb_api/graphql";
 
     private boolean enabled;
 

--- a/backend/src/main/java/net/es/oscars/app/props/EsdbProperties.java
+++ b/backend/src/main/java/net/es/oscars/app/props/EsdbProperties.java
@@ -18,6 +18,9 @@ public class EsdbProperties {
     @NonNull
     private String uri;
 
+    @NonNull
+    private String graphQlUri;
+
     private boolean enabled;
 
     private String vlanSyncPeriod = "PT10M";

--- a/backend/src/main/java/net/es/oscars/dto/esdb/gql/GraphqlEsdbEquipment.java
+++ b/backend/src/main/java/net/es/oscars/dto/esdb/gql/GraphqlEsdbEquipment.java
@@ -1,0 +1,13 @@
+package net.es.oscars.dto.esdb.gql;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+public class GraphqlEsdbEquipment {
+    private String id;
+    public Integer getId() {
+        return Integer.parseInt(id);
+    }
+}

--- a/backend/src/main/java/net/es/oscars/dto/esdb/gql/GraphqlEsdbEquipmentInterface.java
+++ b/backend/src/main/java/net/es/oscars/dto/esdb/gql/GraphqlEsdbEquipmentInterface.java
@@ -1,0 +1,13 @@
+package net.es.oscars.dto.esdb.gql;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+public class GraphqlEsdbEquipmentInterface {
+    private String id;
+    public Integer getId() {
+        return Integer.parseInt(id);
+    }
+}

--- a/backend/src/main/java/net/es/oscars/dto/esdb/gql/GraphqlEsdbVlan.java
+++ b/backend/src/main/java/net/es/oscars/dto/esdb/gql/GraphqlEsdbVlan.java
@@ -1,0 +1,31 @@
+package net.es.oscars.dto.esdb.gql;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+public class GraphqlEsdbVlan {
+    private String id;
+    private String url;
+    private String uuid;
+    private Integer vlanId;
+    private String description;
+    @JsonProperty("bridgeId")
+    private String bridge_id;
+    private GraphqlEsdbEquipment equipment = new GraphqlEsdbEquipment();
+    private GraphqlEsdbEquipmentInterface equipmentInterface = new GraphqlEsdbEquipmentInterface();
+
+    public Integer getId() {
+        return Integer.parseInt(id);
+    }
+
+    public Integer getEquipment() {
+        return equipment.getId();
+    }
+
+    public Integer getEquipmentInterface() {
+        return equipmentInterface.getId();
+    }
+}

--- a/backend/src/main/java/net/es/oscars/esdb/ESDBProxy.java
+++ b/backend/src/main/java/net/es/oscars/esdb/ESDBProxy.java
@@ -1,26 +1,19 @@
 package net.es.oscars.esdb;
 
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.spring.web.v3_1.SpringWebTelemetry;
 import jakarta.validation.constraints.Null;
-import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.app.props.EsdbProperties;
 import net.es.oscars.app.util.HeaderRequestInterceptor;
-import net.es.topo.common.devel.DevelUtils;
-import net.es.topo.common.dto.esdb.EsdbEquip;
+import net.es.oscars.dto.esdb.gql.GraphqlEsdbVlan;
 import net.es.topo.common.dto.esdb.EsdbVlan;
 import net.es.topo.common.dto.esdb.EsdbVlanPayload;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.graphql.GraphQlResponse;
 import org.springframework.graphql.client.ClientGraphQlResponse;
-import org.springframework.graphql.client.ClientResponseField;
 import org.springframework.graphql.client.GraphQlClient;
 import org.springframework.graphql.client.HttpSyncGraphQlClient;
 import org.springframework.http.MediaType;
@@ -258,47 +251,5 @@ public class ESDBProxy {
         String restPath = esdbProperties.getUri()+"vlan/"+vlanPkId+"/";
         log.info("delete rest path: "+restPath);
         restTemplate.delete(restPath);
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    @Data
-    public static class GraphqlEsdbVlan {
-        private String id;
-        private String url;
-        private String uuid;
-        private Integer vlanId;
-        private String description;
-        @JsonProperty("bridgeId")
-        private String bridge_id;
-        private GraphqlEsdbEquipment equipment = new GraphqlEsdbEquipment();
-        private GraphqlEsdbEquipmentInterface equipmentInterface = new GraphqlEsdbEquipmentInterface();
-
-        public Integer getId() {
-            return Integer.parseInt(id);
-        }
-
-        public Integer getEquipment() {
-            return equipment.getId();
-        }
-
-        public Integer getEquipmentInterface() {
-            return equipmentInterface.getId();
-        }
-    }
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    @Data
-    public static class GraphqlEsdbEquipment {
-        private String id;
-        public Integer getId() {
-            return Integer.parseInt(id);
-        }
-    }
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    @Data
-    public static class GraphqlEsdbEquipmentInterface {
-        private String id;
-        public Integer getId() {
-            return Integer.parseInt(id);
-        }
     }
 }

--- a/backend/src/main/java/net/es/oscars/esdb/ESDBProxy.java
+++ b/backend/src/main/java/net/es/oscars/esdb/ESDBProxy.java
@@ -167,12 +167,14 @@ public class ESDBProxy {
                 count: totalRecords
                 list {
                     id,
-                    url,
-                    vlan_id,
+                    vlanId,
                     description,
-                    bridgeId,
-                    equipment,
-                    equipment_interface
+                    equipment {
+                        id
+                    },
+                    equipmentInterface {
+                        id
+                    }
                 }
             }
         }
@@ -181,7 +183,7 @@ public class ESDBProxy {
         );
 
         RestClient restClient = RestClient.create(
-            esdbProperties.getGraphQlUri() + "vlan/"
+            esdbProperties.getGraphqlUri() + "vlan/"
         );
 
         HttpSyncGraphQlClient graphQlClient = HttpSyncGraphQlClient.builder(restClient)

--- a/backend/src/main/java/net/es/oscars/esdb/ESDBProxy.java
+++ b/backend/src/main/java/net/es/oscars/esdb/ESDBProxy.java
@@ -14,9 +14,11 @@ import net.es.topo.common.dto.esdb.EsdbVlan;
 import net.es.topo.common.dto.esdb.EsdbVlanPayload;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.graphql.client.HttpSyncGraphQlClient;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
@@ -60,6 +62,32 @@ public class ESDBProxy {
             return new ArrayList<>();
         }
         return wrapped.results;
+    }
+
+    public List<EsdbVlan> getAllEsdbVlansQuery(String query) {
+        List<EsdbVlan> results = new ArrayList<>();
+
+        String graphqlDocument =
+        """
+        {
+            ""
+        }
+        """;
+
+        RestClient restClient = RestClient.create(
+            esdbProperties.getUri() + "vlan/?limit=0"
+        );
+
+        HttpSyncGraphQlClient graphQlClient = HttpSyncGraphQlClient.builder(restClient)
+            .header("Authorization", "Token " + esdbProperties.getApiKey())
+            .header("Accept", MediaType.APPLICATION_JSON_VALUE)
+            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .build();
+
+        graphQlClient
+            .document(graphqlDocument).executeSync();
+
+        return results;
     }
 
     public void createVlan(EsdbVlanPayload payload) {

--- a/backend/src/main/java/net/es/oscars/task/EsdbVlanSync.java
+++ b/backend/src/main/java/net/es/oscars/task/EsdbVlanSync.java
@@ -53,7 +53,9 @@ public class EsdbVlanSync {
         }
         log.debug("starting VLAN sync");
         // fetch all ESDB vlans
-        List<EsdbVlan> currentEsdbVlans = esdbProxy.getAllEsdbVlans();
+//        List<EsdbVlan> currentEsdbVlans = esdbProxy.getAllEsdbVlans();
+        // ...Use GraphQL client.
+        List<EsdbVlan> currentEsdbVlans = esdbProxy.gqlVlanList();
 
         // generate all the EsdbVlanPayloads from our RESERVED connections
         Set<EsdbVlanPayload> fromReserved = new HashSet<>();

--- a/backend/src/main/java/net/es/oscars/task/EsdbVlanSync.java
+++ b/backend/src/main/java/net/es/oscars/task/EsdbVlanSync.java
@@ -14,7 +14,6 @@ import net.es.oscars.resv.ent.VlanFixture;
 import net.es.oscars.resv.enums.Phase;
 import net.es.oscars.topo.beans.Port;
 import net.es.oscars.topo.svc.TopologyStore;
-import net.es.topo.common.devel.DevelUtils;
 import net.es.topo.common.dto.esdb.EsdbVlan;
 import net.es.topo.common.dto.esdb.EsdbVlanPayload;
 import org.apache.commons.lang3.tuple.Pair;

--- a/backend/src/main/java/net/es/oscars/web/graphql/ConnListController.java
+++ b/backend/src/main/java/net/es/oscars/web/graphql/ConnListController.java
@@ -4,7 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.resv.ent.Connection;
 import net.es.oscars.resv.svc.ConnService;
 import org.springframework.graphql.data.method.annotation.Argument;
-import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.graphql.data.method.annotation.SchemaMapping;
 import org.springframework.stereotype.Controller;
 
 @Controller
@@ -16,7 +16,7 @@ public class ConnListController {
         this.connSvc = connSvc;
     }
 
-    @QueryMapping
+    @SchemaMapping(typeName="OscarsQuery")
     public Connection ConnectionById(@Argument String connectionId) {
         return connSvc.findConnection(connectionId).orElseThrow();
     }

--- a/backend/src/main/resources/graphql-documents/vlanList.graphql
+++ b/backend/src/main/resources/graphql-documents/vlanList.graphql
@@ -1,0 +1,17 @@
+query ($search: String!, $sortProperty:Int, ) {
+    vlanList(search: $search, sortProperty: $sortProperty) {
+        count: totalRecords
+        results : list {
+            id,
+            uuid,
+            vlanId,
+            description,
+            equipment {
+                id
+            },
+            equipmentInterface {
+                id
+            }
+        }
+    }
+}

--- a/backend/src/main/resources/graphql-documents/vlanList.graphql
+++ b/backend/src/main/resources/graphql-documents/vlanList.graphql
@@ -1,4 +1,4 @@
-query ($search: String!, $sortProperty:String, $first:Int!, $skip:Int!) {
+query ($search: String, $sortProperty:String, $first:Int, $skip:Int) {
     vlanList(search: $search, sortProperty: $sortProperty, first: $first, skip: $skip) {
         count: totalRecords
         results : list {

--- a/backend/src/main/resources/graphql-documents/vlanList.graphql
+++ b/backend/src/main/resources/graphql-documents/vlanList.graphql
@@ -1,5 +1,5 @@
-query ($search: String!, $sortProperty:Int, ) {
-    vlanList(search: $search, sortProperty: $sortProperty) {
+query ($search: String!, $sortProperty:String, $first:Int!, $skip:Int!) {
+    vlanList(search: $search, sortProperty: $sortProperty, first: $first, skip: $skip) {
         count: totalRecords
         results : list {
             id,

--- a/backend/src/main/resources/graphql/schema.graphql
+++ b/backend/src/main/resources/graphql/schema.graphql
@@ -1,0 +1,9 @@
+
+type OscarsConnection {
+    connectionId: ID
+    description: String
+}
+
+type OscarsQuery {
+    ConnectionById(connectionId: ID): OscarsConnection
+}

--- a/backend/src/main/resources/graphql/schema.graphqls
+++ b/backend/src/main/resources/graphql/schema.graphqls
@@ -1,8 +1,0 @@
-type Query {
-    ConnectionById(connectionId: ID): Connection
-}
-
-type Connection {
-    connectionId: ID
-    description: String
-}

--- a/backend/src/test/java/net/es/oscars/AbstractBackendTest.java
+++ b/backend/src/test/java/net/es/oscars/AbstractBackendTest.java
@@ -1,10 +1,8 @@
 package net.es.oscars;
 
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootContextLoader;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 

--- a/backend/src/test/java/net/es/oscars/cuke/EsdbVlanSyncSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/EsdbVlanSyncSteps.java
@@ -1,0 +1,78 @@
+package net.es.oscars.cuke;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import net.es.oscars.app.props.NsoProperties;
+import net.es.oscars.ctg.UnitTests;
+import net.es.oscars.esdb.ESDBProxy;
+import net.es.oscars.task.EsdbVlanSync;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.graphql.ResponseError;
+import org.springframework.graphql.client.ClientGraphQlResponse;
+import org.springframework.graphql.client.ClientResponseField;
+import org.springframework.graphql.client.GraphQlClient;
+import org.springframework.graphql.client.HttpSyncGraphQlClient;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@Slf4j
+@Category({UnitTests.class})
+public class EsdbVlanSyncSteps extends CucumberSteps {
+    @Autowired
+    private EsdbVlanSync esdbVlanSync;
+
+    @Autowired
+    private ESDBProxy esdbProxy;
+
+    @Autowired
+    private NsoProperties nsoProperties;
+
+    // Mock server (jetty) port is 50123 in testing.properties
+    private final int mockPort = 50123;
+
+    @Before("@EsdbVlanSyncSteps")
+    public void before() throws IOException {
+        log.info("EsdbVlanSyncSteps before() called.");
+        esdbVlanSync.setSynchronized(false);
+        esdbVlanSync.getStartup().setInStartup(false);
+        esdbVlanSync.getStartup().setInShutdown(false);
+
+        // Override with our mock server URL and port
+        esdbVlanSync.getEsdbProperties().setGraphqlUri("http://localhost:" + mockPort + "/esdb_api/graphql");
+        esdbVlanSync.getEsdbProperties().setUri("http://localhost:" + mockPort + "/esdb_api/v1");
+    }
+
+    @Given("The ESDB VLAN task is ready")
+    public void esdbVlanTaskIsReady() {
+        assert esdbVlanSync != null;
+        assert !esdbVlanSync.isSynchronized();
+    }
+
+    @When("The ESDB VLAN synchronization is triggered")
+    public void theESDBVLANSynchronizationIsTriggered() {
+        esdbVlanSync.processingLoop();
+    }
+
+    @Then("The ESDB VLAN was synchronized")
+    public void theESDBVLANWasSynchronized() {
+        assert esdbVlanSync.isSynchronized();
+    }
+
+}

--- a/backend/src/test/java/net/es/oscars/cuke/NsoVplsStateSyncerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/NsoVplsStateSyncerSteps.java
@@ -5,7 +5,6 @@ import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import kotlin.jvm.Throws;
 import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.ctg.UnitTests;
 import net.es.oscars.sb.nso.NsoProxy;
@@ -20,10 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.net.URI;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;

--- a/backend/src/test/resources/http/esdb.graphql.response-specs.json
+++ b/backend/src/test/resources/http/esdb.graphql.response-specs.json
@@ -1,0 +1,7 @@
+[
+  {
+    "method": "POST",
+    "status": 200,
+    "data": "http/esdb.vlan-list.json"
+  }
+]

--- a/backend/src/test/resources/http/esdb.vlan-list.json
+++ b/backend/src/test/resources/http/esdb.vlan-list.json
@@ -1,0 +1,31 @@
+{
+  "data": {
+    "vlanList": {
+      "count": 2,
+      "results": [
+        {
+          "id": "10943",
+          "vlanId": 2188,
+          "description": "OSCARS DFYG (ORNL AzureGov Sec)",
+          "equipment": {
+            "id": "1717"
+          },
+          "equipmentInterface": {
+            "id": "14117"
+          }
+        },
+        {
+          "id": "2104",
+          "vlanId": 4073,
+          "description": null,
+          "equipment": {
+            "id": "2568"
+          },
+          "equipmentInterface": {
+            "id": "27686"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/backend/src/test/resources/http/esdb.vlan-list.json
+++ b/backend/src/test/resources/http/esdb.vlan-list.json
@@ -5,6 +5,7 @@
       "results": [
         {
           "id": "10943",
+          "uuid": "c8e71a45-29c6-4930-bfb4-e6dd40f3bb75",
           "vlanId": 2188,
           "description": "OSCARS DFYG (ORNL AzureGov Sec)",
           "equipment": {
@@ -16,6 +17,7 @@
         },
         {
           "id": "2104",
+          "uuid": "32de7efb-261e-402e-9354-9f5c84c88b4a",
           "vlanId": 4073,
           "description": null,
           "equipment": {

--- a/backend/src/test/resources/net/es/oscars/cuke/esdb_vlan_sync.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/esdb_vlan_sync.happy.feature
@@ -1,0 +1,9 @@
+@EsdbVlanSyncSteps
+@EsdbVlanSyncStepsHappy
+Feature: Process ESDB VLAN synchronization. (Happy Path)
+
+  Scenario: An ESDB VLAN synchronization is triggered (manual).
+
+    Given The ESDB VLAN task is ready
+    When The ESDB VLAN synchronization is triggered
+    Then The ESDB VLAN was synchronized

--- a/backend/src/test/resources/testing.properties
+++ b/backend/src/test/resources/testing.properties
@@ -66,6 +66,12 @@ nso.routing-domain=esnet-293
 nso.mockPort=50123
 nso.uri=http://localhost:50123/
 
+# ESDB
+esdb.uri=http://localhost:8080/esdb_api/v1
+esdb.graphql-uri=http://localhost:8080/esdb_api/graphql
+
+
+
 proc.timeout-held-after=300
 
 topo.prefix=esnet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD-secret}
       ESDB_API_KEY: ${ESDB_API_KEY}
       ESDB_URI: ${ESDB_URI}
+      ESDB_GRAPHQL_URI: ${ESDB_GRAPHQL_URI:-http://esdb:8000/esdb_api/graphql}
       TOPO_OSCARS_URL: ${TOPO_OSCARS_URL:-http://topo-oscars:8004/oscars-one/topology}
       NSO_USERNAME: ${NSO_USERNAME}
       NSO_PASSWORD: ${NSO_PASSWORD}

--- a/example.env
+++ b/example.env
@@ -2,6 +2,7 @@ NSO_USERNAME="admin"
 NSO_PASSWORD="NsoDocker1337"
 NSO_URI=http://nso/restconf
 ESDB_URI=http://esdb:8000/esdb_api/v1/
+ESDB_GRAPHQL_URI=http://esdb:8000/esdb_api/graphql
 ESDB_API_KEY=foo-bar-baz
 
 


### PR DESCRIPTION
### Description

Updates OSCARS backend scheduled task for ESDB VLAN sync (EsdbVlanSync.processingLoop()) to use a GraphQL client to query ESDB the GraphQL endpoint for ESDB VLAN listings, instead of using a REST client. 

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
