### PR TITLE
feat: [OS-522] Fuzzy connection search

### DIFF
--- a/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
+++ b/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
@@ -60,6 +60,44 @@ public class Connection {
     @JsonIgnore
     private Long id;
 
+    @JsonProperty("bandwidth")
+    private int getBandwidth() {
+        Components cmp;
+        switch (this.phase) {
+            case HELD -> {
+                cmp = this.held.getCmp();
+            }
+            case RESERVED -> {
+                cmp = this.reserved.getCmp();
+
+            }
+            case ARCHIVED -> {
+                cmp = this.archived.getCmp();
+            }
+            default -> { return 0; }
+        }
+        // return the maximum of any of the fixture or pipe bandwidths
+        int result = 0;
+        for (VlanFixture fixture: cmp.getFixtures()) {
+            if (fixture.getEgressBandwidth() > result) {
+                result = fixture.getEgressBandwidth();
+            }
+            if (fixture.getIngressBandwidth() > result) {
+                result = fixture.getIngressBandwidth();
+            }
+        }
+        for (VlanPipe pipe: cmp.getPipes()) {
+            if (pipe.getAzBandwidth() > result) {
+                result = pipe.getAzBandwidth();
+            }
+            if (pipe.getZaBandwidth() > result) {
+                result = pipe.getZaBandwidth();
+            }
+        }
+        return result;
+
+    }
+
     @NonNull
     private String connectionId;
 

--- a/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
@@ -345,10 +345,10 @@ public class ConnService {
                 if (c.getConnectionId().toLowerCase().contains(lowerTerm)) {
                     matching.add(c);
                 }
-                if (c.getDescription().toLowerCase().contains(lowerTerm)) {
+                if (c.getDescription() != null &&  c.getDescription().toLowerCase().contains(lowerTerm)) {
                     matching.add(c);
                 }
-                if (c.getServiceId().toLowerCase().contains(lowerTerm)) {
+                if (c.getServiceId() != null && c.getServiceId().toLowerCase().contains(lowerTerm)) {
                     matching.add(c);
                 }
                 for (Tag t : c.getTags()) {

--- a/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
@@ -356,7 +356,7 @@ public class ConnService {
 
                 // check if the vlanId or any of the edge ports or routers match
                 for (VlanFixture f : c.getArchived().getCmp().getFixtures()) {
-                    if (f.getVlan().getVlanId().toString().contains(lowerTerm)) {
+                    if (f.getVlan().getVlanId().toString().equals(lowerTerm)) {
                         matching.add(c);
                     }
                     if (f.getJunction().getDeviceUrn().toLowerCase().contains(lowerTerm)) {

--- a/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
@@ -348,6 +348,9 @@ public class ConnService {
                 if (c.getDescription().toLowerCase().contains(lowerTerm)) {
                     matching.add(c);
                 }
+                if (c.getServiceId().toLowerCase().contains(lowerTerm)) {
+                    matching.add(c);
+                }
                 for (Tag t : c.getTags()) {
                     if (t.getContents().toLowerCase().contains(lowerTerm)) {
                         matching.add(c);

--- a/backend/src/main/java/net/es/oscars/web/beans/ConnectionFilter.java
+++ b/backend/src/main/java/net/es/oscars/web/beans/ConnectionFilter.java
@@ -19,6 +19,7 @@ public class ConnectionFilter {
     private String username;
     private List<Integer> vlans;
     private List<String> ports;
+    private String term;
     private String description;
     private String southbound;
     private String phase;


### PR DESCRIPTION
### Description

adds a search term to `api/conn/list` that fuzzy-searches connections

it will match connections that match the term
... as a case-insensitive substring in
-the description
- the service id
- any of the connection tags
  - any of the tags associated with the ports or devices in the connection's ERO or terminating ports
  - these include interface descriptions which have Z-numbers and BBL identifiers so you can search for those
...as an exact match for
- the vlan id in any of their endpoints
- the ip address for any of the router loopbacks OR backbone links in the ERO

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
