### PR TITLE
fix: [OS-551] Hot fix - OSCARS Bundle.exclude column, EXCLUDE is a reserved keyword

### DIFF
--- a/backend/src/main/java/net/es/oscars/model/Bundle.java
+++ b/backend/src/main/java/net/es/oscars/model/Bundle.java
@@ -63,8 +63,8 @@ public class Bundle {
         protected List<Waypoint> include;
 
         @ElementCollection
-        @CollectionTable(name="exclude", joinColumns=@JoinColumn(name="bundle_id"))
-        @Column(name="exclude")
+        @CollectionTable(name="`exclude`", joinColumns=@JoinColumn(name="bundle_id"))
+        @Column(name="`exclude`")
         protected Set<Waypoint> exclude;
 
         public List<String> includedUrns() {


### PR DESCRIPTION
### Description

 'EXCLUDE' is a postgresql reserved keyword. Manually quoting column name for OSCARS model Bundle.exclude column

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
