### PR TITLE
fix: [OS-553] Hot fix to OSCARS model Bundle.include column

### DIFF
--- a/backend/src/main/java/net/es/oscars/model/Bundle.java
+++ b/backend/src/main/java/net/es/oscars/model/Bundle.java
@@ -83,7 +83,12 @@ public class Bundle {
     @AllArgsConstructor
     @Getter
     @Setter
-    public static class Waypoint implements Serializable {
+    @Entity
+    public static class Waypoint {
+        @GeneratedValue
+        @JsonIgnore
+        @Id
+        private Long id;
         protected String urn;
         protected UrnType type;
     }

--- a/backend/src/main/java/net/es/oscars/model/Bundle.java
+++ b/backend/src/main/java/net/es/oscars/model/Bundle.java
@@ -58,8 +58,8 @@ public class Bundle {
     public static class Constraints {
 
         @ElementCollection
-        @CollectionTable(name="include", joinColumns=@JoinColumn(name="bundle_id"))
-        @Column(name="include")
+        @CollectionTable(name="`include`", joinColumns=@JoinColumn(name="bundle_id"))
+        @Column(name="`include`")
         protected List<Waypoint> include;
 
         @ElementCollection


### PR DESCRIPTION
### Description

The column named 'include' uses a postgresql reserved keyword as a column name. It must be manually quoted.

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
