### PR TITLE
test: [OS-563] Adding behavior test coverage of NsiService.release()

### DIFF
--- a/backend/src/test/resources/net/es/oscars/cuke/nsi_service.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/nsi_service.happy.feature
@@ -1,6 +1,6 @@
 @NsiServiceSteps
 @NsiServiceStepsHappy
-Feature: Run NSI Service (NsiService) class methods
+Feature: Run NsiService class methods (Happy)
 
   I want to verify NsiService can make a reservation
 
@@ -14,7 +14,7 @@ Feature: Run NSI Service (NsiService) class methods
     When The NSI Service submits a provision request for a reserved connection
     Then The NSI Service made the provision request successfully.
 
-#  Scenario: NSI Service releases a connection
-#    Given The NSI Service class has a provisioned connection
-#    When The NSI Service submits a release request for a provisioned connection
-#    Then The NSI Service made the release request successfully.
+  Scenario: NSI Service releases a connection
+    Given The NSI Service class has a provisioned connection
+    When The NSI Service submits a release request for a provisioned connection
+    Then The NSI Service made the release request successfully.

--- a/backend/src/test/resources/net/es/oscars/cuke/nsi_service.unhappy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/nsi_service.unhappy.feature
@@ -1,0 +1,5 @@
+@NsiServiceSteps
+@NsiServiceStepsUnhappy
+Feature: Run NsiService class methods (Unhappy)
+
+  I want to verify NsiService can handle failure when making a reservation


### PR DESCRIPTION
### Description

Adding happy path (basic) behavior test coverage (cuke) of the NsiService.release() method.

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
