### PR TITLE
feat: [OS-578] Updating oscars-backend service to support nullable projectId property

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -403,6 +403,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
@@ -440,7 +447,7 @@
                     </systemPropertyVariables>
                     <argLine>
                         @{argLine}
-                        -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+                        -javaagent:${org.mockito:mockito-core:jar}
                         -Xshare:off
                     </argLine>
                 </configuration>

--- a/backend/src/main/java/net/es/oscars/esdb/ESDBProxy.java
+++ b/backend/src/main/java/net/es/oscars/esdb/ESDBProxy.java
@@ -57,7 +57,8 @@ public class ESDBProxy {
     /**
      * Get all ESDB VLANS from ESDB using the /vlan endpoint.
      * Deprecated. Please use ESDBProxy.gqlVlanList() instead.
-     * @deprecated
+     * 
+     * @Deprecated
      * @return List of EsdbVlan objects from the REST endpoint response.
      */
     public List<EsdbVlan> getAllEsdbVlans() throws Exception {

--- a/backend/src/main/java/net/es/oscars/model/L2VPN.java
+++ b/backend/src/main/java/net/es/oscars/model/L2VPN.java
@@ -115,6 +115,9 @@ public class L2VPN {
         @JsonFormat(shape = JsonFormat.Shape.NUMBER, timezone = "UTC")
         private Instant lastModified = Instant.now();
 
+        @Schema(description = "Project identifier. This is an external ID", nullable = true)
+        protected String projectId;
+
     }
 
 

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiMappingService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiMappingService.java
@@ -559,10 +559,12 @@ public class NsiMappingService {
         tvt.setValue(mapping.getOscarsConnectionId());
         p2p.getParameter().add(tvt);
 
-        TypeValueType tvtProjectId = new TypeValueType();
-        tvt.setType("projectId");
-        tvt.setValue(c.getProjectId());
-        p2p.getParameter().add(tvtProjectId);
+        if (c.getProjectId() != null) {
+            TypeValueType tvtProjectId = new TypeValueType();
+            tvt.setType("projectId");
+            tvt.setValue(c.getProjectId());
+            p2p.getParameter().add(tvtProjectId);
+        }
 
         String srcStp = mapping.getSrc();
         String dstStp = mapping.getDst();

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiMappingService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiMappingService.java
@@ -550,7 +550,7 @@ public class NsiMappingService {
     }
 
 
-    public P2PServiceBaseType makeP2P(Components cmp, NsiMapping mapping) {
+    public P2PServiceBaseType makeP2P(Components cmp, NsiMapping mapping, Connection c) {
 
         P2PServiceBaseType p2p = new P2PServiceBaseType();
 
@@ -558,6 +558,12 @@ public class NsiMappingService {
         tvt.setType("oscarsId");
         tvt.setValue(mapping.getOscarsConnectionId());
         p2p.getParameter().add(tvt);
+
+        TypeValueType tvtProjectId = new TypeValueType();
+        tvt.setType("projectId");
+        tvt.setValue(c.getProjectId());
+        p2p.getParameter().add(tvtProjectId);
+
         String srcStp = mapping.getSrc();
         String dstStp = mapping.getDst();
         long capacity = 0L;
@@ -611,6 +617,7 @@ public class NsiMappingService {
         p2p.setEro(ero);
         p2p.setDirectionality(DirectionalityType.BIDIRECTIONAL);
         p2p.setSymmetricPath(true);
+        
         return p2p;
     }
 

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiQueries.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiQueries.java
@@ -176,7 +176,7 @@ public class NsiQueries {
         qrrct.setVersion(mapping.getDataplaneVersion());
         Components cmp = getComponents(c);
 
-        P2PServiceBaseType p2p = nsiMappingService.makeP2P(cmp, mapping);
+        P2PServiceBaseType p2p = nsiMappingService.makeP2P(cmp, mapping, c);
 
         net.es.nsi.lib.soap.gen.nsi_2_0.services.point2point.ObjectFactory p2pof
                 = new net.es.nsi.lib.soap.gen.nsi_2_0.services.point2point.ObjectFactory();
@@ -236,7 +236,7 @@ public class NsiQueries {
                 QuerySummaryResultCriteriaType qsrct = new QuerySummaryResultCriteriaType();
                 qsrct.setSchedule(nsiMappingService.oscarsToNsiSchedule(sch));
                 Components cmp = getComponents(c);
-                P2PServiceBaseType p2p = nsiMappingService.makeP2P(cmp, mapping);
+                P2PServiceBaseType p2p = nsiMappingService.makeP2P(cmp, mapping, c);
                 net.es.nsi.lib.soap.gen.nsi_2_0.services.point2point.ObjectFactory p2pof = new ObjectFactory();
                 qsrct.getAny().add(p2pof.createP2Ps(p2p));
                 qsrct.setServiceType(NsiService.SERVICE_TYPE);

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
@@ -18,6 +18,7 @@ import net.es.nsi.lib.soap.gen.nsi_2_0.framework.headers.CommonHeaderType;
 import net.es.nsi.lib.soap.gen.nsi_2_0.framework.types.TypeValuePairType;
 import net.es.nsi.lib.soap.gen.nsi_2_0.services.point2point.P2PServiceBaseType;
 import net.es.nsi.lib.soap.gen.nsi_2_0.services.types.OrderedStpType;
+import net.es.nsi.lib.soap.gen.nsi_2_0.services.types.TypeValueType;
 import net.es.oscars.app.exc.*;
 import net.es.oscars.model.Interval;
 import net.es.oscars.nsi.beans.*;
@@ -1034,6 +1035,12 @@ public class NsiService {
         ConnectionMode connectionMode = ConnectionMode.NEW;
         String projectId = null;
 
+        for (TypeValueType tvt : p2ps.getParameter()) {
+            if (tvt.getType().equals("projectId") && tvt.getValue() != null) {
+                projectId = tvt.getValue();
+            }
+        }
+
         if (optC.isPresent()) {
             Connection c = optC.get();
             connectionMode = ConnectionMode.MODIFY;
@@ -1054,7 +1061,7 @@ public class NsiService {
             fixtures = fjp.getLeft();
             junctions = fjp.getRight();
             pipes = nsiMappingService.pipesFor(interval, mbps, junctions, include);
-            projectId = c.getProjectId();
+            
         } else {
             // a new reserve
             log.info("got p2p for new reserve");

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
@@ -1036,7 +1036,7 @@ public class NsiService {
         String projectId = null;
 
         for (TypeValueType tvt : p2ps.getParameter()) {
-            if (tvt.getType().equals("projectId") && tvt.getValue() != null) {
+            if (tvt.getType().equals("projectId") && tvt.getValue() != null && !tvt.getValue().isEmpty()) {
                 projectId = tvt.getValue();
             }
         }

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
@@ -828,7 +828,7 @@ public class NsiService {
         rcct.setServiceType(SERVICE_TYPE);
         rcct.setVersion(mapping.getDataplaneVersion());
 
-        P2PServiceBaseType p2p = nsiMappingService.makeP2P(cmp, mapping);
+        P2PServiceBaseType p2p = nsiMappingService.makeP2P(cmp, mapping, c);
         rcct.getAny().add(new ObjectFactory().createP2Ps(p2p));
 
         try {
@@ -1032,6 +1032,7 @@ public class NsiService {
 
         List<String> include = new ArrayList<>();
         ConnectionMode connectionMode = ConnectionMode.NEW;
+        String projectId = null;
 
         if (optC.isPresent()) {
             Connection c = optC.get();
@@ -1053,7 +1054,7 @@ public class NsiService {
             fixtures = fjp.getLeft();
             junctions = fjp.getRight();
             pipes = nsiMappingService.pipesFor(interval, mbps, junctions, include);
-
+            projectId = c.getProjectId();
         } else {
             // a new reserve
             log.info("got p2p for new reserve");
@@ -1109,6 +1110,7 @@ public class NsiService {
                     .tags(tags)
                     .connection_mtu(9000)
                     .username("nsi")
+                    .projectId(projectId)
                     .build();
             try {
                 String pretty = jacksonObjectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(simpleConnection);

--- a/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
+++ b/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
@@ -1,6 +1,8 @@
 package net.es.oscars.resv.ent;
 
 import com.fasterxml.jackson.annotation.*;
+
+import io.micrometer.common.lang.Nullable;
 import jakarta.persistence.*;
 import lombok.*;
 import net.es.oscars.resv.enums.*;
@@ -34,7 +36,8 @@ public class Connection {
                       @JsonProperty("held") Held held,
                       @JsonProperty("archived") Archived archived,
                       @JsonProperty("connection_mtu") @NonNull Integer connection_mtu,
-                      @JsonProperty("last_modified") @NonNull Integer last_modified) {
+                      @JsonProperty("last_modified") @NonNull Integer last_modified,
+                      @JsonProperty("projectId") @Nullable String projectId) {
         this.connectionId = connectionId;
         this.phase = phase;
         this.mode = mode;
@@ -50,6 +53,8 @@ public class Connection {
         this.archived = archived;
         this.connection_mtu = connection_mtu;
         this.last_modified = last_modified;
+
+        this.projectId = projectId;
     }
 
 
@@ -148,6 +153,9 @@ public class Connection {
 
     @Transient
     public ConnectionSouthbound southbound;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String projectId;
 
     @Override
     public final boolean equals(Object o) {

--- a/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
+++ b/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
@@ -37,7 +37,7 @@ public class Connection {
                       @JsonProperty("archived") Archived archived,
                       @JsonProperty("connection_mtu") @NonNull Integer connection_mtu,
                       @JsonProperty("last_modified") @NonNull Integer last_modified,
-                      @JsonProperty("projectId") @Nullable String projectId) {
+                      @JsonProperty("projectId") String projectId) {
         this.connectionId = connectionId;
         this.phase = phase;
         this.mode = mode;

--- a/backend/src/main/java/net/es/oscars/resv/svc/ConnUtils.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ConnUtils.java
@@ -220,6 +220,7 @@ public class ConnUtils {
                 .tags(new ArrayList<>())
                 .connection_mtu(in.getConnection_mtu())
                 .serviceId(in.getServiceId())
+                .projectId(in.getProjectId())
                 .build();
 
         log.debug("setting a held connection " + c.getConnectionId());
@@ -467,6 +468,7 @@ public class ConnUtils {
                 .fixtures(fixtures)
                 .junctions(junctions)
                 .pipes(pipes)
+                .projectId(c.getProjectId())
                 .build());
     }
 

--- a/backend/src/main/java/net/es/oscars/resv/svc/conversions/L2VPNConversions.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/conversions/L2VPNConversions.java
@@ -184,6 +184,7 @@ public class L2VPNConversions {
                 .username(c.getUsername())
                 .trackingId(c.getServiceId())
                 .orchId(null)
+                .projectId(c.getProjectId())
                 .build();
     }
 
@@ -343,6 +344,11 @@ public class L2VPNConversions {
             }
         }
 
+        String projectId = null;
+        if (l2VPNRequest.getMeta() != null && l2VPNRequest.getMeta().getProjectId() != null) {
+            l2VPNRequest.getMeta().getProjectId();
+        }
+
         return SimpleConnection.builder()
                 .username(l2VPNRequest.getMeta().getUsername())
                 .connection_mtu(l2VPNRequest.getTech().getMtu())
@@ -358,6 +364,7 @@ public class L2VPNConversions {
                 .fixtures(fixtures)
                 .junctions(new ArrayList<>(junctions))
                 .pipes(pipes)
+                .projectId(projectId)
                 .build();
 
     }

--- a/backend/src/main/java/net/es/oscars/topo/pop/TopoPopulator.java
+++ b/backend/src/main/java/net/es/oscars/topo/pop/TopoPopulator.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.*;
 

--- a/backend/src/main/java/net/es/oscars/web/rest/HoldController.java
+++ b/backend/src/main/java/net/es/oscars/web/rest/HoldController.java
@@ -15,7 +15,6 @@ import net.es.oscars.web.beans.CurrentlyHeldEntry;
 import net.es.oscars.web.simple.SimpleConnection;
 import net.es.oscars.web.simple.Validity;
 import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.transaction.annotation.Transactional;

--- a/backend/src/main/java/net/es/oscars/web/simple/SimpleConnection.java
+++ b/backend/src/main/java/net/es/oscars/web/simple/SimpleConnection.java
@@ -40,5 +40,6 @@ public class SimpleConnection {
     protected String description;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     protected Validity validity;
+    protected String projectId;
 
 }

--- a/backend/src/main/java/net/es/oscars/web/simple/SimpleConnection.java
+++ b/backend/src/main/java/net/es/oscars/web/simple/SimpleConnection.java
@@ -40,6 +40,7 @@ public class SimpleConnection {
     protected String description;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     protected Validity validity;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     protected String projectId;
 
 }

--- a/backend/src/test/java/net/es/oscars/cuke/EseApiControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/EseApiControllerSteps.java
@@ -255,6 +255,7 @@ public class EseApiControllerSteps extends CucumberSteps {
             .meta(
                 L2VPN.Meta.builder()
                     .username("test-user")
+                    .projectId("ABCD-1234-EFGH-5678")
                     .build()
             )
             .schedule(
@@ -452,6 +453,7 @@ public class EseApiControllerSteps extends CucumberSteps {
             .description("test description")
             .connection_mtu(10000)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
+            .projectId("ABCD-1234-EFGH-5678")
             .build();
     }
 

--- a/backend/src/test/java/net/es/oscars/cuke/HoldControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/HoldControllerSteps.java
@@ -107,6 +107,9 @@ public class HoldControllerSteps {
         controller.setConnRepo(connRepo);
     }
     private Connection generateMockConnection() {
+        return generateMockConnection(null);
+    }
+    private Connection generateMockConnection(String projectId) {
         return Connection.builder()
             .connectionId("ABCD")
             .phase(Phase.HELD)
@@ -118,7 +121,7 @@ public class HoldControllerSteps {
             .description("test description")
             .connection_mtu(10000)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
-            .projectId("ABCD-1234-EFGH-5678")
+            .projectId(null)
             .build();
     }
     private void setupMockConnSvc() throws Exception {
@@ -148,22 +151,49 @@ public class HoldControllerSteps {
             );
 
         // Mock ConnService.holdConnection(), returns Tuple <SimpleConnection, Connection>
+        SimpleConnection simpleConnection = helper.createSimpleConnection(
+            "ABCD",
+            10000,
+            10000,
+            10000,
+            10000,
+            10000
+        );
+
+        SimpleConnection simpleConnectionWithProjectId = helper.createSimpleConnection(
+            "ABCD",
+            10000,
+            10000,
+            10000,
+            10000,
+            10000,
+            "ABCD-1234-EFGH-5678"
+        );
+
         Pair<SimpleConnection, Connection> mockHoldConnection = Pair.of(
-            helper.createSimpleConnection(
-                10000,
-                10000,
-                10000,
-                10000,
-                10000
-            ),
+            simpleConnection,
             generateMockConnection()
+        );
+        Pair<SimpleConnection, Connection> mockHoldConnectionWithProjectId = Pair.of(
+            simpleConnectionWithProjectId,
+            generateMockConnection("ABCD-1234-EFGH-5678")
         );
         Mockito
             .when(
                 connSvc.holdConnection(Mockito.any(SimpleConnection.class))
             )
-            .thenReturn(
-                mockHoldConnection
+            .thenAnswer(
+                invocation -> {
+                    Pair<SimpleConnection, Connection> mockResult = null;
+                    SimpleConnection s = (SimpleConnection) invocation.getArgument(0);
+                    if (s.getProjectId() == null) {
+                        mockResult = mockHoldConnection;
+                    } else {
+                        mockResult = mockHoldConnectionWithProjectId;
+                    }
+                    
+                    return mockResult;
+                }
             );
 
         connSvc.setConnRepo(connRepo);
@@ -206,6 +236,7 @@ public class HoldControllerSteps {
 
             ObjectMapper mapper = new ObjectMapper();
             SimpleConnection simpleConnection = helper.createSimpleConnection(
+                "ABCD",
                 10000,
                 10000,
                 10000,
@@ -217,6 +248,38 @@ public class HoldControllerSteps {
             HttpEntity<String> entity = new HttpEntity<>(payload, headers);
 
             response = restTemplate.exchange(httpPath, method, entity, String.class);
+        } catch (Exception ex) {
+            world.add(ex);
+            log.error(ex.getLocalizedMessage(), ex);
+        }
+    }
+
+    @Given("The client executes POST with SimpleConnection payload on HoldController path {string} and projectId {string}")
+    public void theClientExecutesWithSimpleConnectionPayloadOnHoldControllerPathAndProjectId(String httpPath, String projectId) throws Throwable {
+        HttpMethod method = HttpMethod.POST;
+        try {
+            log.info("Executing " + method + " on HoldController path " + httpPath);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+            ObjectMapper mapper = new ObjectMapper();
+            SimpleConnection simpleConnection = helper.createSimpleConnection(
+                "ABCD",
+                10000,
+                10000,
+                10000,
+                10000,
+                10000,
+                projectId
+            );
+            String payload = mapper.writeValueAsString(simpleConnection);
+
+            HttpEntity<String> entity = new HttpEntity<>(payload, headers);
+
+            response = restTemplate.exchange(httpPath, method, entity, String.class);
+            log.info("response from {} is {}", httpPath, response.getStatusCode());
         } catch (Exception ex) {
             world.add(ex);
             log.error(ex.getLocalizedMessage(), ex);
@@ -271,5 +334,15 @@ public class HoldControllerSteps {
             world.add(ex);
             log.error(ex.getLocalizedMessage(), ex);
         }
+    }
+
+    @Then("The HoldController response does not have a projectId field")
+    public void theHoldControllerResponseDoesNotHaveAProjectIdField() {
+
+    }
+
+    @Then("The HoldController response does have a projectId field")
+    public void theHoldControllerResponseDoesHaveAProjectIdField() {
+
     }
 }

--- a/backend/src/test/java/net/es/oscars/cuke/HoldControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/HoldControllerSteps.java
@@ -118,6 +118,7 @@ public class HoldControllerSteps {
             .description("test description")
             .connection_mtu(10000)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
+            .projectId("ABCD-1234-EFGH-5678")
             .build();
     }
     private void setupMockConnSvc() throws Exception {

--- a/backend/src/test/java/net/es/oscars/cuke/MockSimpleConnectionHelper.java
+++ b/backend/src/test/java/net/es/oscars/cuke/MockSimpleConnectionHelper.java
@@ -471,7 +471,20 @@ public class MockSimpleConnectionHelper {
             10000
         );
     }
+
     public Connection generateMockConnection(String mockConnectionId, Phase phase, BuildMode buildMode, State state, DeploymentState deploymentState, DeploymentIntent deploymentIntent, int connection_mtu) {
+        return generateMockConnection(
+            mockConnectionId,
+            phase,
+            buildMode,
+            state,
+            deploymentState,
+            deploymentIntent,
+            connection_mtu,
+            null
+        );
+    }
+    public Connection generateMockConnection(String mockConnectionId, Phase phase, BuildMode buildMode, State state, DeploymentState deploymentState, DeploymentIntent deploymentIntent, int connection_mtu, String projectId) {
         return Connection.builder()
             .id(1L)
             .held( // Required, or /protected/modify/description result will become an HTTP 500 Internal Server Error
@@ -499,7 +512,7 @@ public class MockSimpleConnectionHelper {
             .description("test description")
             .connection_mtu(connection_mtu)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
-            .projectId("ABCD-1234-EFGH-5678")
+            .projectId(projectId)
             .build();
     }
 }

--- a/backend/src/test/java/net/es/oscars/cuke/MockSimpleConnectionHelper.java
+++ b/backend/src/test/java/net/es/oscars/cuke/MockSimpleConnectionHelper.java
@@ -239,6 +239,7 @@ public class MockSimpleConnectionHelper {
             .pipes(         this.connectionPipes)
             .last_modified( this.beginTime )
             .validity( this.createTrueValidity() )
+            .projectId("ABCD-1234-EFGH-5678")
             .build();
     }
 
@@ -357,6 +358,7 @@ public class MockSimpleConnectionHelper {
             .deploymentState(DeploymentState.UNDEPLOYED)
             .deploymentIntent(DeploymentIntent.SHOULD_BE_UNDEPLOYED)
             .last_modified(this.beginTime)
+            .projectId("ABCD-1234-EFGH-5678")
             .build();
         this.held.put(mockConnection.getConnectionId(), mockConnection);
 
@@ -497,6 +499,7 @@ public class MockSimpleConnectionHelper {
             .description("test description")
             .connection_mtu(connection_mtu)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
+            .projectId("ABCD-1234-EFGH-5678")
             .build();
     }
 }

--- a/backend/src/test/java/net/es/oscars/cuke/MockSimpleConnectionHelper.java
+++ b/backend/src/test/java/net/es/oscars/cuke/MockSimpleConnectionHelper.java
@@ -52,6 +52,8 @@ public class MockSimpleConnectionHelper {
     private Instant beginInstant;
     private Instant endInstant;
 
+    private String projectId = null;
+
     public SimpleConnection createValidSimpleConnection() throws Exception {
         return  this.createSimpleConnection(
             1000,
@@ -158,7 +160,10 @@ public class MockSimpleConnectionHelper {
     public SimpleConnection createSimpleConnection(int inMbps, int outMpbs, int azMbps, int zaMbps, int mbps) throws Exception {
         return createSimpleConnection("ABCD", inMbps, outMpbs, azMbps, zaMbps, mbps);
     }
-    public SimpleConnection createSimpleConnection(String connectionId, int inMbps, int outMpbs, int azMbps, int zaMbps, int mbps) throws Exception {
+    public SimpleConnection createSimpleConnection(String connectionId, int inMbps, int outMbps, int azMbps, int zaMbps, int mbps) throws Exception {
+        return createSimpleConnection(connectionId, inMbps, outMbps, azMbps, zaMbps, mbps, null);
+    }
+    public SimpleConnection createSimpleConnection(String connectionId, int inMbps, int outMpbs, int azMbps, int zaMbps, int mbps, String projectId) throws Exception {
         // Create a valid SimpleConnection object
         this.connectionId = connectionId;
         this.connection_mtu = 9000;
@@ -169,6 +174,7 @@ public class MockSimpleConnectionHelper {
         this.phase = Phase.DESIGN;
         this.userName = "testuser";
         this.state = State.WAITING;
+        this.projectId = projectId;
 
         // @TODO: Need a mock list of fixtures, junctions, and pipes
         this.connectionFixtures = createFixtures(inMbps, outMpbs, mbps);
@@ -239,7 +245,7 @@ public class MockSimpleConnectionHelper {
             .pipes(         this.connectionPipes)
             .last_modified( this.beginTime )
             .validity( this.createTrueValidity() )
-            .projectId("ABCD-1234-EFGH-5678")
+            .projectId(projectId)
             .build();
     }
 
@@ -358,7 +364,7 @@ public class MockSimpleConnectionHelper {
             .deploymentState(DeploymentState.UNDEPLOYED)
             .deploymentIntent(DeploymentIntent.SHOULD_BE_UNDEPLOYED)
             .last_modified(this.beginTime)
-            .projectId("ABCD-1234-EFGH-5678")
+            .projectId(this.projectId)
             .build();
         this.held.put(mockConnection.getConnectionId(), mockConnection);
 

--- a/backend/src/test/java/net/es/oscars/cuke/TopoSearchControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/TopoSearchControllerSteps.java
@@ -139,6 +139,7 @@ public class TopoSearchControllerSteps {
             .description("test description")
             .connection_mtu(10000)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
+            .projectId("ABCD-1234-EFGH-5678")
             .build();
     }
     private void setupMockConnSvc() throws Exception {

--- a/backend/src/test/resources/cucumber.properties
+++ b/backend/src/test/resources/cucumber.properties
@@ -1,1 +1,3 @@
 cucumber.publish.quiet=true
+cucumber.features=src/test/resources/**/*.feature
+cucumber.glue=net.es.oscars.cuke

--- a/backend/src/test/resources/net/es/oscars/cuke/hold_controller.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/hold_controller.happy.feature
@@ -31,3 +31,10 @@ Feature: Test the HoldController endpoints (Happy)
     When The client receives a response from HoldController
     Then The client receives a HoldController response status code of 200
     And The HoldController response is a valid SimpleConnection
+
+  Scenario: Sending an HTTP POST payload to /protected/hold with a projectId field
+    # Note, /protected/pcehold just calls the function handler for /protected/hold
+    Given The client executes POST with SimpleConnection payload on HoldController path "/protected/hold" and projectId "ABCD-1234-EFGH-5678"
+    When The client receives a response from HoldController
+    Then The client receives a HoldController response status code of 200
+    And The HoldController response is a valid SimpleConnection

--- a/backend/src/test/resources/net/es/oscars/cuke/nsi_service.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/nsi_service.happy.feature
@@ -4,9 +4,16 @@ Feature: Run NsiService class methods (Happy)
 
   I want to verify NsiService can make a reservation
 
-  Scenario: NSI Service makes a connection reservation
+  Scenario: NSI Service makes a connection reservation (with optional projectId field)
+    Given The NSI Service class is instantiated
+    When The NSI Service submits a reservation for OSCARS connection ID "ABCD", global reservation ID "GLOBALID", NSI connection ID "RES1", project ID "abcd-1234-efgh-5678"
+    Then The connection has a projectId value
+    Then The NSI Service made the reservation successfully.
+
+  Scenario: NSI Service makes a connection reservation (without optional projectId field)
     Given The NSI Service class is instantiated
     When The NSI Service submits a reservation for OSCARS connection ID "ABCD", global reservation ID "GLOBALID", NSI connection ID "RES1"
+    Then the connection does not have a projectId value
     Then The NSI Service made the reservation successfully.
 
   Scenario: NSI Service provisions a connection


### PR DESCRIPTION
### Description

Adds a "projectId" field to Connectino, SimpleConnection, and L2VPN.Meta class, and ensures all builder() calls include the projectId field when available.

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
