### PR TITLE
test: [OS-484] NSI reserve, RESERVE_CHECKING -> RESERVE_HELD

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -338,11 +338,11 @@
             <scope>test</scope>
         </dependency>
     
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-text</artifactId>
-        <version>1.14.0</version>
-      </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.14.0</version>
+        </dependency>
     </dependencies>
     <reporting>
         <plugins>

--- a/backend/src/main/java/net/es/oscars/app/util/AsyncCallback.java
+++ b/backend/src/main/java/net/es/oscars/app/util/AsyncCallback.java
@@ -1,0 +1,6 @@
+package net.es.oscars.app.util;
+
+public interface AsyncCallback<T> {
+    void onSuccess(T result);
+    void onFailure(Throwable thrown);
+}

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiConnectionEventService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiConnectionEventService.java
@@ -1,5 +1,6 @@
 package net.es.oscars.nsi.svc;
 
+import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.nsi.db.NsiConnectionEventRepository;
 import net.es.oscars.nsi.ent.NsiConnectionEvent;
@@ -8,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @Slf4j
+@Data
 public class NsiConnectionEventService {
 
     private final NsiConnectionEventRepository eventRepo;

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
@@ -116,6 +116,7 @@ public class NsiService {
                 // this will throw an NsiMappingException if it fails and do an errCallback
                 mapping = nsiMappingService.newMapping(nsiConnectionId, nsiGri, nsaId, incomingRT.getCriteria().getVersion(), false);
                 nsiMappingService.save(mapping);
+                nsiStateEngine.getReserveHandler().onSuccess(mapping);
             } else {
                 log.info("transitioning NSI state: RESV_CHECK {}", mapping.getNsiConnectionId());
                 nsiStateEngine.reserve(NsiEvent.RESV_CHECK, mapping);

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiStateEngine.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiStateEngine.java
@@ -35,6 +35,15 @@ public class NsiStateEngine {
         reserveHandler.onSuccess(mapping);
     }
 
+    /**
+     * Reserve (hold) a new connection.
+     * NSI Reservation state transition:
+     *  - RESERVE_CHECKING -> RESERVE_HELD (if resources are available)
+     *  - RESERVE_CHECKING -> RESERVE_FAILED
+     * @param event
+     * @param mapping
+     * @throws NsiStateException
+     */
     public void reserve(NsiEvent event, NsiMapping mapping) throws NsiStateException {
         if (event.equals(NsiEvent.RESV_START)) {
             if (!mapping.getReservationState().equals(ReservationStateEnumType.RESERVE_START)) {
@@ -180,6 +189,16 @@ public class NsiStateEngine {
         mapping.setLifecycleState(LifecycleStateEnumType.TERMINATED);
     }
 
+    /**
+     * Commit a held reservation, and start it.
+     * 
+     * NSI Reservation state transition:
+     *  - RESERVE_HELD -> RESERVE_COMMITTING -> RESERVE_START
+     * 
+     * @param event
+     * @param mapping
+     * @throws NsiStateException
+     */
     public void commit(NsiEvent event, NsiMapping mapping) throws NsiStateException {
 
 

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiStateEngine.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiStateEngine.java
@@ -3,8 +3,11 @@ package net.es.oscars.nsi.svc;
 import net.es.nsi.lib.soap.gen.nsi_2_0.connection.types.LifecycleStateEnumType;
 import net.es.nsi.lib.soap.gen.nsi_2_0.connection.types.ProvisionStateEnumType;
 import net.es.nsi.lib.soap.gen.nsi_2_0.connection.types.ReservationStateEnumType;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.app.exc.NsiStateException;
+import net.es.oscars.app.util.AsyncCallback;
 import net.es.oscars.nsi.beans.NsiErrors;
 import net.es.oscars.nsi.beans.NsiEvent;
 import net.es.oscars.nsi.ent.NsiMapping;
@@ -17,33 +20,61 @@ import java.util.Set;
 @Slf4j
 public class NsiStateEngine {
 
+    /**
+     * An internal handler that can be used to receive a callback when the reserve() function transitions internally between ReservationStateEnumType states.
+     * Not to be confused with the URI callback mechanism.
+     */
+    @Getter
+    @Setter
+    private AsyncCallback<NsiMapping> reserveHandler;
+
+    private void reserveHandlerTriggerOnFailure(NsiStateException nsiEx) {
+        if (reserveHandler != null) reserveHandler.onFailure(nsiEx);
+    }
+    private void reserveHandlerTriggerOnSuccess(NsiMapping mapping) {
+        reserveHandler.onSuccess(mapping);
+    }
+
     public void reserve(NsiEvent event, NsiMapping mapping) throws NsiStateException {
         if (event.equals(NsiEvent.RESV_START)) {
             if (!mapping.getReservationState().equals(ReservationStateEnumType.RESERVE_START)) {
-                throw new NsiStateException("Invalid reservation state " + mapping.getReservationState(), NsiErrors.TRANS_ERROR);
+                NsiStateException nsiEx = new NsiStateException("Invalid reservation state " + mapping.getReservationState(), NsiErrors.TRANS_ERROR);
+                reserveHandlerTriggerOnFailure(nsiEx);
+                throw nsiEx;
             }
             mapping.setReservationState(ReservationStateEnumType.RESERVE_START);
+            reserveHandlerTriggerOnSuccess(mapping);
 
         } else if (event.equals(NsiEvent.RESV_CHECK)) {
             if (!mapping.getReservationState().equals(ReservationStateEnumType.RESERVE_START)) {
-                throw new NsiStateException("Invalid reservation state " + mapping.getReservationState(), NsiErrors.TRANS_ERROR);
+                NsiStateException nsiEx = new NsiStateException("Invalid reservation state " + mapping.getReservationState(), NsiErrors.TRANS_ERROR);
+                reserveHandlerTriggerOnFailure(nsiEx);
+                throw nsiEx;
             }
 
             mapping.setReservationState(ReservationStateEnumType.RESERVE_CHECKING);
+            reserveHandlerTriggerOnSuccess(mapping);
 
         } else if (event.equals(NsiEvent.RESV_FL)) {
             if (!mapping.getReservationState().equals(ReservationStateEnumType.RESERVE_CHECKING)) {
-                throw new NsiStateException("Invalid reservation state " + mapping.getReservationState(), NsiErrors.TRANS_ERROR);
+                NsiStateException nsiEx = new NsiStateException("Invalid reservation state " + mapping.getReservationState(), NsiErrors.TRANS_ERROR);
+                reserveHandlerTriggerOnFailure(nsiEx);
+                throw nsiEx;
             }
 
             mapping.setReservationState(ReservationStateEnumType.RESERVE_FAILED);
+            reserveHandlerTriggerOnSuccess(mapping);
         } else if (event.equals(NsiEvent.RESV_CF)) {
             if (!mapping.getReservationState().equals(ReservationStateEnumType.RESERVE_CHECKING)) {
-                throw new NsiStateException("Invalid reservation state " + mapping.getReservationState(), NsiErrors.TRANS_ERROR);
+                NsiStateException nsiEx = new NsiStateException("Invalid reservation state " + mapping.getReservationState(), NsiErrors.TRANS_ERROR);
+                throw nsiEx;
             }
             mapping.setReservationState(ReservationStateEnumType.RESERVE_HELD);
+            reserveHandlerTriggerOnSuccess(mapping);
         } else {
-            throw new NsiStateException("Invalid event " + event, NsiErrors.TRANS_ERROR);
+            NsiStateException nsiEx = new NsiStateException("Invalid event " + event, NsiErrors.TRANS_ERROR);
+            reserveHandlerTriggerOnFailure(nsiEx);
+            throw nsiEx;
         }
 
     }

--- a/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
@@ -48,6 +48,9 @@ import static net.es.oscars.app.util.PrettyPrinter.prettyLog;
 import static net.es.oscars.resv.svc.ConnUtils.*;
 import static net.es.oscars.sb.nso.NsoAdapter.NSO_TEMPLATE_VERSION;
 
+/**
+ * ConnService - Connection Service class. Please note, "connectionId" here refers to an OSCARS connection ID.
+ */
 @Service
 @Slf4j
 @Data
@@ -1080,18 +1083,22 @@ public class ConnService {
         return error;
     }
 
-
-    public Optional<Connection> findConnection(String connectionId) {
-        if (connectionId == null || connectionId.isEmpty()) {
+    /**
+     * Find a connection by OSCARS connection ID. Not to be confused with an NSI connection ID.
+     * @param connectionId The OSCARS connection ID to search for.
+     * @return Optional<Connection> A connection wrapped in an Optional container object.
+     */
+    public Optional<Connection> findConnection(String oscarsConnectionId) {
+        if (oscarsConnectionId == null || oscarsConnectionId.isEmpty()) {
             return Optional.empty();
         }
 
-        if (held.containsKey(connectionId)) {
-            return Optional.of(held.get(connectionId));
+        if (held.containsKey(oscarsConnectionId)) {
+            return Optional.of(held.get(oscarsConnectionId));
         }
 
-//        log.info("looking for connectionId "+ connectionId);
-        Optional<Connection> cOpt = connRepo.findByConnectionId(connectionId);
+//        log.info("looking for oscarsConnectionId "+ oscarsConnectionId);
+        Optional<Connection> cOpt = connRepo.findByConnectionId(oscarsConnectionId);
         if (cOpt.isPresent()) {
 
             Connection c = cOpt.get();

--- a/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
@@ -1,8 +1,6 @@
 package net.es.oscars.resv.svc;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.app.exc.PCEException;
@@ -26,7 +24,6 @@ import net.es.oscars.topo.beans.*;
 import net.es.oscars.topo.svc.TopologyStore;
 import net.es.oscars.web.beans.*;
 import net.es.oscars.web.simple.*;
-import net.es.topo.common.devel.DevelUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jgrapht.alg.connectivity.ConnectivityInspector;

--- a/backend/src/test/java/net/es/oscars/cuke/NsiProviderSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/NsiProviderSteps.java
@@ -4,14 +4,11 @@ import static net.es.oscars.app.util.PrettyPrinter.prettyLog;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-
 import org.apache.commons.text.StringSubstitutor;
 import org.junit.experimental.categories.Category;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +21,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StreamUtils;
 import org.w3c.dom.Document;
-import org.w3c.dom.DocumentType;
 import org.w3c.dom.Element;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -33,10 +29,6 @@ import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBElement;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
 import jakarta.xml.soap.MessageFactory;
 import jakarta.xml.soap.SOAPBody;
 import jakarta.xml.soap.SOAPMessage;
@@ -49,14 +41,12 @@ import net.es.oscars.nsi.ent.NsiConnectionEvent;
 import net.es.oscars.nsi.svc.NsiAsyncQueue;
 import net.es.oscars.nsi.svc.NsiConnectionEventService;
 import net.es.oscars.nsi.svc.NsiService;
-import net.es.oscars.resv.ent.Connection;
 import net.es.oscars.resv.svc.ConnService;
 import net.es.oscars.soap.NsiProvider;
 import net.es.oscars.topo.TopoService;
 import net.es.oscars.topo.beans.Topology;
 import net.es.oscars.topo.pop.TopoPopulator;
 import net.es.oscars.topo.svc.TopologyStore;
-import net.es.oscars.resv.enums.Phase;
 
 @Slf4j
 @Category({UnitTests.class})

--- a/backend/src/test/java/net/es/oscars/cuke/NsiProviderSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/NsiProviderSteps.java
@@ -189,6 +189,61 @@ public class NsiProviderSteps extends CucumberSteps {
         assert world.getExceptions().size() == errorCount;
     }
 
+    @Given("A connection is not reserved yet")
+    public void A_connection_is_not_reserved_yet() {
+        // Write code here that turns the phrase above into concrete actions
+    }
+
+    @Given("A connection reservation state is {string}")
+    public void A_connection_reservation_state_is_reserve_checking(String expectedReservationState) {
+        // Write code here that turns the phrase above into concrete actions
+    }
+
+    @When("An NSI connection reserve is requested")
+    public void An_NSI_connection_reserve_is_requested() {
+        // Write code here that turns the phrase above into concrete actions
+    }
+
+    @When("The resources ARE available")
+    public void The_resources_ARE_available() {
+        // Write code here that turns the phrase above into concrete actions
+    }
+
+    @When("The resources ARE NOT available")
+    public void The_resources_ARE_NOT_available() {
+        // Write code here that turns the phrase above into concrete actions
+    }
+
+    @Then("The NSI mapping and connection object is created")
+    public void The_NSI_mapping_and_connection_object_is_created() {
+        // Write code here that turns the phrase above into concrete actions
+    }
+
+    @Then("The reservation state is now {string}")
+    public void The_reservation_state_is_now_reserve_held(String expectedReservationState) {
+        // Write code here that turns the phrase above into concrete actions
+    }
+
+    @Then("The resources are no longer available for something else")
+    public void The_resources_are_no_longer_available_for_something_else() {
+        // Write code here that turns the phrase above into concrete actions
+    }
+
+    @Then("The resources are available for something else")
+    public void The_resources_are_available_for_something_else() {
+        // Write code here that turns the phrase above into concrete actions
+    }
+
+    @Then("The reserveConfirmed message callback is triggered")
+    public void The_reserveConfirmed_message_callback_is_triggered() {
+        // Write code here that turns the phrase above into concrete actions
+    }
+
+    @Then("The reserveFailed message callback is triggered")
+    public void The_reserveFailed_message_callback_is_triggered() {
+        // Write code here that turns the phrase above into concrete actions
+    }
+
     private void loadTopology() throws Exception {
         String topoPath = "topo/esnet.json";
         Topology t = topoPopulator.loadTopology(topoPath);

--- a/backend/src/test/resources/net/es/oscars/cuke/nsi_provider.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/nsi_provider.happy.feature
@@ -28,42 +28,21 @@ Feature: The NSI SOAP API provider endpoints (Happy)
     Scenario: NSI Reserve test suite - not reserved yet
 
         # Draft NSI CS protocol 2.1 v13 at https://redmine.ogf.org/attachments/286/draft-nsi-cs-protocol-2dot1-v13.pdf
-        # The initial state of a connection reservation is non-existent.
-        # When the NsiProvider receives a connection reservation request (SOAP XML),
-        # it will log a "RESERVE_RECEIVED" connection event to the database,
-        # and internally go through the ReservationStateEnumType enumeration states.
         # See  https://gitlab.es.net/esnet/nsi-soap/-/blob/main/src/main/java/net/es/nsi/lib/soap/gen/nsi_2_0/connection/types/ReservationStateEnumType.java?ref_type=heads
-        #
-        # When requesting to reserve a connection, pg. 12 of the draft NSI CS protocol 2.1 v13 shows the following flow:
-        #   
-        #   RESERVE_START -> RESERVE_CHECKING -> (if resource is available) -> RESERVE_HELD
-        #   ... if a timeout occurs, it goes RESERVE_HELD -> RESERVE_TIMEOUT 
-        #           -> (diagram shows illogical possibility of going to RESERVE_COMMITTING, but most likely goes to RESERVE_ABORTING) 
-        #           -> RESERVE_START
-        # 
-        #   ... or RESERVE_HELD -> (no notes on this) -> RESERVE_ABORTING -> RESERVE_START
-        #     or
-        #   RESERVE_START -> RESERVE_CHECKING -> (if resource is NOT available) -> RESERVE_FAILED
-        #   ... it will then transition to RESERVe_ABORTING -> RESERVE_START
-        #
-        # When 
 
 
+        # NSI reserve() hold
         Given The connection is not reserved yet
         When An NSI connection reserve is requested
         Then The latest connection event type is "RESERVE_RECEIVED"
         Then The NSI queue is processed
-        
-        # This is what the NSI specs say should happen...
-        # Then The reservation state path was "RESERVE_START -> RESERVE_CHECKING -> RESERVE_HELD"
-
-        # ...but, this is what currently happens
         Then The reservation state path was "RESERVE_CHECKING -> RESERVE_HELD"
 
-        Then The reservation state is now "RESERVE_HELD"
+        # NSI commit()
+        # Given The reservation state is now "RESERVE_HELD"
+        # When An NSI connection commit is requested
+        # Then The NSI queue is processed
+        # Then The reservation state path was "RESERVE_CHECKING -> RESERVE_HELD -> RESERVE_COMMITTING -> RESERVE_START"
 
-        Given The reservation state is now "RESERVE_HELD"
-        # Given The NSI queue is processed
-        # When The NSI mapping and connection object is created
-        # Then The latest connection event type is "RESERVE_CONFIRM"
-        # Then The reservation state is now "RESERVE_HELD"
+
+

--- a/backend/src/test/resources/net/es/oscars/cuke/nsi_provider.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/nsi_provider.happy.feature
@@ -26,21 +26,26 @@ Feature: The NSI SOAP API provider endpoints (Happy)
        And The NSI provider encountered 0 errors
 
     Scenario: NSI Reserve test suite - not reserved yet
-        Given A connection is not reserved yet
+
+        Given The connection is not reserved yet
         When An NSI connection reserve is requested
         Then The NSI mapping and connection object is created
-        And The reservation state is now "reserve checking"
+        # And The reservation state is now "reserve checking"
+        And The reservation state is now "RESERVE_RECEIVED"
 
-    Scenario: NSI Reserve test suite - reservation state is "reserve checking", resources available
-        Given A connection reservation state is "reserve checking"
+        
+        # Given The connection reservation state is "reserve checking"
+        Given The connection reservation state is "RESERVE_RECEIVED"
+        When The NSI reserve is requested
         When The resources ARE available
-        Then The reservation state is now "reserve held"
+        # Then The reservation state is now "reserve held"
+        Then The reservation state is now "RESERVE_CONFIRM"
         And The resources are no longer available for something else
         And The reserveConfirmed message callback is triggered
 
-    Scenario: NSI Reserve test suite - reservation state is "reserve checking", resources not available
-        Given A connection reservation state is "reserve checking"
-        When The resources ARE NOT available
-        Then The reservation state is now "reserve failed"
-        And The resources are available for something else
-        And The reserveFailed message callback is triggered
+        # Given The connection reservation state is "reserve checking"
+        # When The resources ARE NOT available
+        # #Then The reservation state is now "reserve failed"
+        # Then The reservation state is now "RESERVE_FAILED"
+        # And The resources are available for something else
+        # And The reserveFailed message callback is triggered

--- a/backend/src/test/resources/net/es/oscars/cuke/nsi_provider.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/nsi_provider.happy.feature
@@ -27,7 +27,43 @@ Feature: The NSI SOAP API provider endpoints (Happy)
 
     Scenario: NSI Reserve test suite - not reserved yet
 
+        # Draft NSI CS protocol 2.1 v13 at https://redmine.ogf.org/attachments/286/draft-nsi-cs-protocol-2dot1-v13.pdf
+        # The initial state of a connection reservation is non-existent.
+        # When the NsiProvider receives a connection reservation request (SOAP XML),
+        # it will log a "RESERVE_RECEIVED" connection event to the database,
+        # and internally go through the ReservationStateEnumType enumeration states.
+        # See  https://gitlab.es.net/esnet/nsi-soap/-/blob/main/src/main/java/net/es/nsi/lib/soap/gen/nsi_2_0/connection/types/ReservationStateEnumType.java?ref_type=heads
+        #
+        # When requesting to reserve a connection, pg. 12 of the draft NSI CS protocol 2.1 v13 shows the following flow:
+        #   
+        #   RESERVE_START -> RESERVE_CHECKING -> (if resource is available) -> RESERVE_HELD
+        #   ... if a timeout occurs, it goes RESERVE_HELD -> RESERVE_TIMEOUT 
+        #           -> (diagram shows illogical possibility of going to RESERVE_COMMITTING, but most likely goes to RESERVE_ABORTING) 
+        #           -> RESERVE_START
+        # 
+        #   ... or RESERVE_HELD -> (no notes on this) -> RESERVE_ABORTING -> RESERVE_START
+        #     or
+        #   RESERVE_START -> RESERVE_CHECKING -> (if resource is NOT available) -> RESERVE_FAILED
+        #   ... it will then transition to RESERVe_ABORTING -> RESERVE_START
+        #
+        # When 
+
+
         Given The connection is not reserved yet
         When An NSI connection reserve is requested
         Then The latest connection event type is "RESERVE_RECEIVED"
+        Then The NSI queue is processed
+        
+        # This is what the NSI specs say should happen...
+        # Then The reservation state path was "RESERVE_START -> RESERVE_CHECKING -> RESERVE_HELD"
+
+        # ...but, this is what currently happens
+        Then The reservation state path was "RESERVE_CHECKING -> RESERVE_HELD"
+
         Then The reservation state is now "RESERVE_HELD"
+
+        Given The reservation state is now "RESERVE_HELD"
+        # Given The NSI queue is processed
+        # When The NSI mapping and connection object is created
+        # Then The latest connection event type is "RESERVE_CONFIRM"
+        # Then The reservation state is now "RESERVE_HELD"

--- a/backend/src/test/resources/net/es/oscars/cuke/nsi_provider.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/nsi_provider.happy.feature
@@ -4,7 +4,7 @@ Feature: The NSI SOAP API provider endpoints (Happy)
     Scenario: An NSI connection is reserved without a projectId field
         Given The NSI connection is queued for asynchronous reservation while not including a projectId
         Given The NSI queue size is 1
-        When The NSI reserve is requested
+        When The NSI queue is processed
         Then The NSI connection is put on hold
         And The NSI connection does not have a projectId
         And The NSI provider encountered 0 errors
@@ -12,7 +12,7 @@ Feature: The NSI SOAP API provider endpoints (Happy)
    Scenario: An NSI connection is reserved with a projectId field
        Given The NSI connection is queued for asynchronous reservation while including a projectId
        Given The NSI queue size is 1
-       When The NSI reserve is requested
+       When The NSI queue is processed
        Then The NSI connection is put on hold
        And The NSI connection has a projectId
        And The NSI provider encountered 0 errors
@@ -20,7 +20,7 @@ Feature: The NSI SOAP API provider endpoints (Happy)
     Scenario: An NSI connection is reserved with a blank projectId field
        Given The NSI connection is queued for asynchronous reservation while including a blank projectId
        Given The NSI queue size is 1
-       When The NSI reserve is requested
+       When The NSI queue is processed
        Then The NSI connection is put on hold
        And The NSI connection does not have a projectId
        And The NSI provider encountered 0 errors
@@ -29,23 +29,5 @@ Feature: The NSI SOAP API provider endpoints (Happy)
 
         Given The connection is not reserved yet
         When An NSI connection reserve is requested
-        Then The NSI mapping and connection object is created
-        # And The reservation state is now "reserve checking"
-        And The reservation state is now "RESERVE_RECEIVED"
-
-        
-        # Given The connection reservation state is "reserve checking"
-        Given The connection reservation state is "RESERVE_RECEIVED"
-        When The NSI reserve is requested
-        When The resources ARE available
-        # Then The reservation state is now "reserve held"
-        Then The reservation state is now "RESERVE_CONFIRM"
-        And The resources are no longer available for something else
-        And The reserveConfirmed message callback is triggered
-
-        # Given The connection reservation state is "reserve checking"
-        # When The resources ARE NOT available
-        # #Then The reservation state is now "reserve failed"
-        # Then The reservation state is now "RESERVE_FAILED"
-        # And The resources are available for something else
-        # And The reserveFailed message callback is triggered
+        Then The latest connection event type is "RESERVE_RECEIVED"
+        Then The reservation state is now "RESERVE_HELD"

--- a/backend/src/test/resources/net/es/oscars/cuke/nsi_provider.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/nsi_provider.happy.feature
@@ -8,6 +8,7 @@ Feature: The NSI SOAP API provider endpoints (Happy)
         Then The NSI connection is put on hold
         And The NSI connection does not have a projectId
         And The NSI provider encountered 0 errors
+
    Scenario: An NSI connection is reserved with a projectId field
        Given The NSI connection is queued for asynchronous reservation while including a projectId
        Given The NSI queue size is 1
@@ -23,3 +24,23 @@ Feature: The NSI SOAP API provider endpoints (Happy)
        Then The NSI connection is put on hold
        And The NSI connection does not have a projectId
        And The NSI provider encountered 0 errors
+
+    Scenario: NSI Reserve test suite - not reserved yet
+        Given A connection is not reserved yet
+        When An NSI connection reserve is requested
+        Then The NSI mapping and connection object is created
+        And The reservation state is now "reserve checking"
+
+    Scenario: NSI Reserve test suite - reservation state is "reserve checking", resources available
+        Given A connection reservation state is "reserve checking"
+        When The resources ARE available
+        Then The reservation state is now "reserve held"
+        And The resources are no longer available for something else
+        And The reserveConfirmed message callback is triggered
+
+    Scenario: NSI Reserve test suite - reservation state is "reserve checking", resources not available
+        Given A connection reservation state is "reserve checking"
+        When The resources ARE NOT available
+        Then The reservation state is now "reserve failed"
+        And The resources are available for something else
+        And The reserveFailed message callback is triggered


### PR DESCRIPTION
### Description

Heads up! Includes refactoring to some of our Nsi classes to enable internal state change tracking (NSI reserve).
This set of changes addresses the happy path when attempting to reserve a new connection via the NsiProvider reserve() endpoint (SOAP XML).

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [x] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [ ] This PR includes tests related to these changes, or existing tests provide coverage
- [x] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
