### PR TITLE
fix: [OS-634] make sure NSO dismantles happen before builds / redeploys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # OSCARS Release Notes
 ### 1.2.33
 > Sep 2025
+- OS-634 NSO operation reordering
 - OS-617 defensive programming against topo NPE 
 - OS-618 try to stop sending null values to NSO
 

--- a/backend/src/main/java/net/es/oscars/sb/SouthboundQueuer.java
+++ b/backend/src/main/java/net/es/oscars/sb/SouthboundQueuer.java
@@ -15,11 +15,11 @@ import net.es.oscars.resv.enums.State;
 import net.es.oscars.sb.nso.resv.NsoResourceService;
 import net.es.oscars.sb.nso.resv.NsoResvException;
 import net.es.topo.common.devel.DevelUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 
 @Component
@@ -43,32 +43,53 @@ public class SouthboundQueuer {
 
     @Transactional
     public void process() {
+
+        // Skip "duplicate" tasks that are already running (or planned) - if we are already
+        // performing (or planning to perform) a DISMANTLE for connection ABCD, we don't
+        // want to do that again
+
+        // We initialize a set of <connectionId, commandType> tuples to keep track,
+        // and fill it with data from all the currently running tasks..
+        Set<Pair<String, CommandType>> runningOrPlanned = new HashSet<>();
         for (SouthboundTask rt : running) {
-            log.info("running : " + rt.getConnectionId() + " " + rt.getCommandType());
+            runningOrPlanned.add(Pair.of(rt.getConnectionId(), rt.getCommandType()));
         }
 
-        // TODO: ensure we don't do opposite tasks for the same connection; last should win
-        List<SouthboundTask> shouldRun = new ArrayList<>();
+        List<SouthboundTask> dupesEliminated = new ArrayList<>();
         for (SouthboundTask wt : waiting) {
-            log.info("waiting : " + wt.getConnectionId() + " " + wt.getCommandType());
-            boolean foundSame = false;
-            for (SouthboundTask rt : running) {
-                if (rt.getCommandType().equals(wt.getCommandType()) &&
-                        rt.getConnectionId().equals(wt.getConnectionId())) {
-                    log.info("already running " + wt.getConnectionId() + " " + wt.getCommandType());
-                    foundSame = true;
-                }
-            }
-            if (!foundSame) {
-                shouldRun.add(wt);
+            Pair<String, CommandType> tuple = Pair.of(wt.getConnectionId(), wt.getCommandType());
+            // If the tuple set does _not_ contain our <connectionId, commandType>, we should run the task
+            // We also add the tuple to the set.
+            if (!runningOrPlanned.contains(tuple)) {
+                runningOrPlanned.add(tuple);
+                dupesEliminated.add(wt);
             }
         }
 
-        running.addAll(shouldRun);
 
-        for (SouthboundTask wt : shouldRun) {
+        // Now we reorder the list by doing DISMANTLEs before any BUILDs and REDEPLOYs
+        // Reason is, if this scenario comes up:
+        // connection ABCD is now deployed, using resource 1000, we are asked to DISMANTLE it
+        // connection DEFG is undeployed, plans to use resource 1000, we are asked to BUILD it
+        //
+        // then we must do the ABCD DISMANTLE before the DEFG build or NSO will throw an error
+
+        // make two lists, filter our tasks to either...
+        List<SouthboundTask> dismantles = new ArrayList<>();
+        List<SouthboundTask> others = new ArrayList<>();
+        for (SouthboundTask sbt : dupesEliminated) {
+            if (sbt.getCommandType().equals(CommandType.DISMANTLE)) {
+                dismantles.add(sbt);
+            } else {
+                others.add(sbt);
+            }
+        }
+        // then join the two lists, putting the dismantles first
+        List<SouthboundTask> dismantlesFirst = new ArrayList<>(dismantles);
+        dismantlesFirst.addAll(others);
+
+        for (SouthboundTask wt : dismantlesFirst) {
             log.info("running task : " + wt.getConnectionId() + " " + wt.getCommandType());
-
             cr.findByConnectionId(wt.getConnectionId()).ifPresent(conn -> {
                 if (wt.getCommandType().equals(CommandType.BUILD)) {
                     conn.setDeploymentState(DeploymentState.BEING_DEPLOYED);

--- a/backend/src/test/java/net/es/oscars/cuke/SouthboundQueuerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/SouthboundQueuerSteps.java
@@ -1,0 +1,165 @@
+package net.es.oscars.cuke;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.extern.slf4j.Slf4j;
+import net.es.oscars.ctg.UnitTests;
+import net.es.oscars.dto.pss.cmd.CommandType;
+import net.es.oscars.sb.SouthboundQueuer;
+import net.es.oscars.sb.SouthboundTask;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.experimental.categories.Category;
+
+import java.util.*;
+
+@Slf4j
+@Category({UnitTests.class})
+public class SouthboundQueuerSteps extends CucumberSteps {
+    private List<SouthboundTask> processedTasks;
+    private List<SouthboundTask> running;
+    private List<SouthboundTask> waiting;
+
+    @When("^I submit multiple duplicate tasks to the queue preprocesor$")
+    public void submit_dupe_tasks() {
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.BUILD)
+                .connectionId("ABCD")
+                .build());
+
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.BUILD)
+                .connectionId("ABCD")
+                .build());
+
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.DISMANTLE)
+                .connectionId("DEFG")
+                .build());
+
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.DISMANTLE)
+                .connectionId("DEFG")
+                .build());
+
+        processedTasks = SouthboundQueuer.preprocessQueue(waiting, running);
+    }
+
+
+    @Then("the processed queue does not have duplicate tasks for the same connection id")
+    public void theProcessedQueueDoesNotHaveDuplicateTasksForTheSameConnectionId() {
+        Set<Pair<String, CommandType>> dupeCheckerMap = new HashSet<>();
+        for (SouthboundTask task : processedTasks) {
+            Pair<String, CommandType> pair = Pair.of(task.getConnectionId(), task.getCommandType());
+            if (!dupeCheckerMap.contains(pair)) {
+                dupeCheckerMap.add(pair);
+            } else {
+                assert false;
+            }
+        }
+    }
+
+
+    @When("I submit a mix of tasks to the queue preprocesor")
+    public void iSubmitAMixOfTasksToTheQueuePreprocesor() {
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.BUILD)
+                .connectionId("ABCD")
+                .build());
+
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.BUILD)
+                .connectionId("ABCD")
+                .build());
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.REDEPLOY)
+                .connectionId("ABCD")
+                .build());
+
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.DISMANTLE)
+                .connectionId("ABCD")
+                .build());
+
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.BUILD)
+                .connectionId("DEFG")
+                .build());
+
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.DISMANTLE)
+                .connectionId("DEFG")
+                .build());
+
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.DISMANTLE)
+                .connectionId("DEFG")
+                .build());
+
+        processedTasks = SouthboundQueuer.preprocessQueue(waiting, running);
+
+    }
+
+    @Then("the processed queue does not have any non-dismantle tasks ahead of any dismantle task")
+    public void theProcessedQueueDoesNotHaveAnyNonDismantleTasksAheadOfAnyDismantleTask() {
+        boolean gotNonDismantle = false;
+        for (SouthboundTask task : processedTasks) {
+            if (task.getCommandType() == CommandType.DISMANTLE) {
+                // it is a DISMANTLE task
+                if (gotNonDismantle) {
+                    assert false;
+                }
+            } else {
+                gotNonDismantle = true;
+            }
+
+        }
+    }
+
+    @When("I submit a task that is already in the running queue to the queue preprocesor")
+    public void iSubmitATaskThatIsAlreadyInTheRunningQueueToTheQueuePreprocesor() {
+        running.add(SouthboundTask.builder()
+                .commandType(CommandType.BUILD)
+                .connectionId("ABCD")
+                .build());
+
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.BUILD)
+                .connectionId("ABCD")
+                .build());
+
+        waiting.add(SouthboundTask.builder()
+                .commandType(CommandType.DISMANTLE)
+                .connectionId("DEFG")
+                .build());
+        processedTasks = SouthboundQueuer.preprocessQueue(waiting, running);
+    }
+
+    @Then("the processed queue does not contain any tasks that are in the running queue")
+    public void theProcessedQueueDoesNotContainAnyTasksThatAreInTheRunningQueue() {
+        Set<Pair<String, CommandType>> dupeCheckerMap = new HashSet<>();
+        for (SouthboundTask task : running) {
+            Pair<String, CommandType> pair = Pair.of(task.getConnectionId(), task.getCommandType());
+            if (!dupeCheckerMap.contains(pair)) {
+                dupeCheckerMap.add(pair);
+            } else {
+                assert false;
+            }
+        }
+
+        for (SouthboundTask task : processedTasks) {
+            Pair<String, CommandType> pair = Pair.of(task.getConnectionId(), task.getCommandType());
+            if (!dupeCheckerMap.contains(pair)) {
+                dupeCheckerMap.add(pair);
+            } else {
+                assert false;
+            }
+        }
+    }
+
+    @Given("I clear waiting and running queues")
+    public void iClearWaitingAndRunningQueues() {
+        running = new ArrayList<>();
+        waiting = new ArrayList<>();
+    }
+}

--- a/backend/src/test/resources/net/es/oscars/cuke/southbound_queuer.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/southbound_queuer.happy.feature
@@ -1,0 +1,17 @@
+@SouthboundQueuerSteps
+Feature: ensure the southbound queuer preprocesses its waiting queue correctly
+
+  Scenario: Make sure duplicate tasks are not added to the queue
+    Given I clear waiting and running queues
+    When I submit multiple duplicate tasks to the queue preprocesor
+    Then the processed queue does not have duplicate tasks for the same connection id
+
+  Scenario: Make sure tasks already in the running queue are not added to the queue
+    Given I clear waiting and running queues
+    When I submit a task that is already in the running queue to the queue preprocesor
+    Then the processed queue does not contain any tasks that are in the running queue
+
+  Scenario: Make sure dismantle tasks at the head of the queue
+    Given I clear waiting and running queues
+    When I submit a mix of tasks to the queue preprocesor
+    Then the processed queue does not have any non-dismantle tasks ahead of any dismantle task


### PR DESCRIPTION
### Description

small change in the NSO southbound queuer to make sure any DISMANTLEs happen before BUILDs and REDEPLOYs.

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [x] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
