### PR TITLE
test: [OS-590] update ESE controller tests to use real OSCARS logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 > Sep 2025
 - OS-617 defensive programming against topo NPE 
 - OS-618 try to stop sending null values to NSO
+- OS-590 de-mockify EseApiController tests
 
 ### 1.2.32
 > Sep 2025

--- a/backend/src/main/java/net/es/oscars/topo/beans/v2/Bandwidth.java
+++ b/backend/src/main/java/net/es/oscars/topo/beans/v2/Bandwidth.java
@@ -2,6 +2,8 @@ package net.es.oscars.topo.beans.v2;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -21,6 +23,13 @@ public class Bandwidth {
 
     @NonNull
     private Integer physical;
+
+    private Double utilization;
+
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    public void setUtilization(Double utilization) {
+        this.utilization = utilization;
+    }
 
     @JsonGetter
     private Double utilization() {

--- a/backend/src/main/java/net/es/oscars/topo/beans/v2/EdgePort.java
+++ b/backend/src/main/java/net/es/oscars/topo/beans/v2/EdgePort.java
@@ -14,6 +14,13 @@ import java.util.Set;
 @AllArgsConstructor
 @NoArgsConstructor
 public class EdgePort {
+    private String urn;
+
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    public void setUrn(String urn) {
+        this.urn = urn;
+    }
+
     @JsonGetter("urn")
     public String getUrn() {
         return device+":"+name;

--- a/backend/src/main/java/net/es/oscars/topo/beans/v2/VlanAvailability.java
+++ b/backend/src/main/java/net/es/oscars/topo/beans/v2/VlanAvailability.java
@@ -1,6 +1,9 @@
 package net.es.oscars.topo.beans.v2;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.sun.xml.xsom.impl.scd.Step;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,6 +21,19 @@ import java.util.Set;
 public class VlanAvailability {
 
     private Set<IntRange> ranges;
+    private String expression;
+    private List<List<Integer>> tuples;
+
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    public void setExpression(String expression) {
+        this.expression = expression;
+    }
+
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    public void setTuples(List<List<Integer>> tuples) {
+        this.tuples = tuples;
+    }
+
 
     @JsonGetter("expression")
     private String asExpression() {

--- a/backend/src/test/java/net/es/oscars/cuke/CucumberWorld.java
+++ b/backend/src/test/java/net/es/oscars/cuke/CucumberWorld.java
@@ -1,5 +1,6 @@
 package net.es.oscars.cuke;
 
+import net.es.oscars.model.L2VPN;
 import net.es.oscars.resv.beans.PeriodBandwidth;
 import net.es.oscars.resv.ent.Design;
 import net.es.oscars.resv.ent.EroHop;
@@ -26,6 +27,8 @@ public class CucumberWorld {
     Map<String, TopoUrn> topoBaseline ;
     Design design;
     Map<EroDirection, List<EroHop>> pipeEros;
+
+    L2VPN l2vpn;
 
 
     public void expectException() {

--- a/backend/src/test/java/net/es/oscars/cuke/EseApiControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/EseApiControllerSteps.java
@@ -24,6 +24,10 @@ import net.es.oscars.resv.ent.Held;
 import net.es.oscars.resv.enums.*;
 import net.es.oscars.resv.svc.ConnService;
 import net.es.oscars.resv.svc.L2VPNService;
+import net.es.oscars.topo.beans.TopoException;
+import net.es.oscars.topo.beans.Topology;
+import net.es.oscars.topo.pop.TopoPopulator;
+import net.es.oscars.topo.svc.TopologyStore;
 import net.es.oscars.web.beans.BandwidthAvailabilityResponse;
 import net.es.oscars.web.beans.ConnectionFilter;
 import net.es.oscars.web.beans.v2.L2VPNList;
@@ -39,6 +43,7 @@ import org.springframework.http.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.*;
 
@@ -72,10 +77,13 @@ public class EseApiControllerSteps extends CucumberSteps {
     @MockitoBean
     private Authentication authentication;
 
-    @Autowired
-    private MockSimpleConnectionHelper helper;
-
     private ResponseEntity<String> response;
+
+    @Autowired
+    private TopoPopulator topoPopulator;
+
+    @Autowired
+    private TopologyStore topologyStore;
 
     @MockitoBean
     L2VPNService l2VPNService;
@@ -96,12 +104,19 @@ public class EseApiControllerSteps extends CucumberSteps {
         mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
 
+        try {
+            Topology t = topoPopulator.loadTopology("topo/esnet.json");
+            topologyStore.replaceTopology(t);
+            startup.setInStartup(false);
+        } catch (TopoException | IOException e) {
+            throw new RuntimeException(e);
+        }
+
         // Reset stuff
         clear();
 
         // Setup mock data sources
         MockitoAnnotations.openMocks(this);
-        setupDatasources();
 
         // Mock startup
         startup.setInStartup(false);
@@ -109,189 +124,6 @@ public class EseApiControllerSteps extends CucumberSteps {
 
     private void clear() {
         response = null;
-    }
-
-    private void setupDatasources() throws Exception {
-//        setupMockL2VPNConversions();
-        setupMockConnService();
-        setupMockL2VPNService();
-        setupMockUsernameGetter();
-    }
-
-//    private void setupMockL2VPNConversions() throws Exception {
-//        Mockito
-//            .when(
-//                L2VPNConversions.fromConnection(Mockito.any(Connection.class))
-//            )
-//            .thenReturn(
-//                generateMockL2VPN()
-//            );
-//    }
-
-    private void setupMockConnService() throws Exception {
-        connSvc = Mockito.mock(ConnService.class);
-        Connection mockConn = generateMockConnection();
-        Optional<Connection> mockConnOpt = Optional.of(mockConn);
-
-        // Mock ConnService.findConnection()
-        // ...requires ConnService.held data property (Map<String, Connection>)
-        connSvc.setHeld(Map.of("ABCD", mockConn));
-        Mockito
-            .doReturn(mockConnOpt).when(
-            connSvc
-        ).findConnection(Mockito.anyString());
-    }
-
-    private void setupMockL2VPNService() throws Exception {
-        l2VPNService = Mockito.mock(L2VPNService.class);
-
-        l2VPNService.setConnSvc(connSvc);
-
-        // TODO: Setup mock handlers for L2VPNService class methods
-        // Mock L2VPNService.get()
-        L2VPN mockL2VPN = generateMockL2VPN();
-
-        Mockito
-            .doReturn(
-                mockL2VPN
-            )
-            .when(
-                l2VPNService
-            ).get(
-                Mockito.anyString()
-            );
-
-        // Mock L2VPNService.list()
-        List<L2VPN> mockL2VPNs = new ArrayList<>();
-        mockL2VPNs.add(mockL2VPN);
-
-        L2VPNList mockL2VPNList = L2VPNList.builder()
-            .page(1)
-            .sizePerPage(1)
-            .totalSize(1)
-            .l2vpns(mockL2VPNs)
-            .build();
-
-        Mockito
-            .when(
-                l2VPNService.list(
-                    Mockito.any(ConnectionFilter.class)
-                )
-            )
-            .thenReturn(
-                mockL2VPNList
-            );
-
-        // Mock L2VPNService.create()
-        Mockito
-            .when(
-                l2VPNService.createOrReplace(Mockito.any(L2VPN.class))
-            )
-            .thenReturn(
-                mockL2VPN
-            );
-        // Mock L2VPNService.bwAvailability()
-        Mockito
-            .when(
-                l2VPNService.bwAvailability(Mockito.any(L2VPN.class))
-            )
-            .thenReturn(
-                BandwidthAvailabilityResponse.builder()
-                    .available(1)
-                    .baseline(1)
-                    .build()
-            );
-        Mockito
-                .when(
-                        l2VPNService.validate(Mockito.any(L2VPN.class), Mockito.any(ConnectionMode.class))
-                )
-                .thenReturn(
-                        ValidationResponse.builder()
-                                .valid(true)
-                                .message("OK")
-                                .build()
-                );
-        controller.setL2VPNService(l2VPNService);
-    }
-
-    private L2VPN generateMockL2VPN() {
-        List<Bundle> mockBundles = new ArrayList<>();
-        List<Endpoint> mockEndpoints = new ArrayList<>();
-
-        mockBundles.add(
-            Bundle.builder()
-                .id(1L)
-                .name("TestBundle1")
-                .a("test1-cr6")
-                .z("test2-cr6")
-                .constraints(
-                    Bundle.Constraints.builder()
-                        .build()
-                )
-                .build()
-        );
-
-        mockEndpoints.add(
-            Endpoint.builder()
-                .id(1L)
-                .device("test1-cr6")
-                .port("1/1/c32/1")
-                .vlan(122)
-                .tagged(false)
-                .build()
-        );
-        mockEndpoints.add(
-            Endpoint.builder()
-                .id(2L)
-                .device("test2-cr6")
-                .port("1/1/c32/2")
-                .vlan(122)
-                .tagged(false)
-                .build()
-        );
-        return L2VPN.builder()
-            .id(1L)
-            .name("TEST")
-            .meta(
-                L2VPN.Meta.builder()
-                    .username("test-user")
-                    .projectId("ABCD-1234-EFGH-5678")
-                    .build()
-            )
-            .schedule(
-                Interval.builder()
-                    .build()
-            )
-            .status(
-                L2VPN.Status.builder()
-                    .build()
-            )
-            .qos(
-                L2VPN.Qos.builder()
-                    .build()
-            )
-            .tech(
-                L2VPN.Tech.builder()
-                    .build()
-            )
-            .bundles(mockBundles)
-            .endpoints(mockEndpoints)
-            .build();
-    }
-
-    private void setupMockUsernameGetter() throws Exception {
-        usernameGetter = Mockito.mock(UsernameGetter.class);
-
-        // Mock UsernameGetter.username()
-        Mockito
-            .doReturn("test-user")
-            .when(
-                usernameGetter
-
-            )
-            .username(Mockito.any());
-
-        controller.setUsernameGetter(usernameGetter);
     }
 
     @Given("The client executes {string} on EseApiController path {string}")
@@ -354,7 +186,7 @@ public class EseApiControllerSteps extends CucumberSteps {
             headers.setContentType(MediaType.APPLICATION_JSON);
             headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
 
-            L2VPN requestPayload = generateMockL2VPN();
+            L2VPN requestPayload = world.l2vpn;
 
             String payload = mapper.writeValueAsString(requestPayload);
 
@@ -425,37 +257,6 @@ public class EseApiControllerSteps extends CucumberSteps {
         assert responseObject != null;
     }
 
-    private Connection generateMockConnection() {
-        return Connection.builder()
-            .id(1L)
-            .held( // Required, or /protected/modify/description result will become an HTTP 500 Internal Server Error
-                Held.builder()
-                    .connectionId("ABCD")
-                    .cmp(
-                        Components.builder()
-                            .id(1L)
-                            .fixtures(new ArrayList<>())
-                            .junctions(new ArrayList<>())
-                            .pipes(new ArrayList<>())
-                            .build()
-                    )
-                    .expiration(Instant.now().plusSeconds(60 * 20)) // 20 minutes from now
-                    .schedule(helper.createValidSchedule())
-                    .build()
-            )
-            .connectionId("ABCD")
-            .phase(Phase.HELD)
-            .mode(BuildMode.AUTOMATIC)
-            .state(State.WAITING)
-            .deploymentState(DeploymentState.UNDEPLOYED)
-            .deploymentIntent(DeploymentIntent.SHOULD_BE_DEPLOYED)
-            .username("test")
-            .description("test description")
-            .connection_mtu(10000)
-            .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
-            .projectId("ABCD-1234-EFGH-5678")
-            .build();
-    }
 
     @And("The EseApiController response is a valid ValidationResponse object")
     public void theEseApiControllerResponseIsAValidValidationResponseObject() throws JsonProcessingException {

--- a/backend/src/test/java/net/es/oscars/cuke/L2vpnSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/L2vpnSteps.java
@@ -100,6 +100,7 @@ public class L2vpnSteps extends CucumberSteps {
         // modify the schedule
         request.getSchedule().setBeginning(Instant.now().plus(1, ChronoUnit.MINUTES));
         request.getSchedule().setEnding(Instant.now().plus(30, ChronoUnit.MINUTES));
+        world.l2vpn = request;
     }
 
     @When("I validate the new L2VPN request")

--- a/backend/src/test/resources/net/es/oscars/cuke/ese_api_controller.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/ese_api_controller.happy.feature
@@ -1,8 +1,16 @@
 @EseApiControllerSteps
 @EseApiControllerStepsHappy
 Feature: EseApiController Endpoints for l2VPNs
-  Scenario: Get the l2VPN of connection ID "ABCD"
-    Given The client executes "GET" on EseApiController path "/api/l2vpn/get/ABCD"
+  Scenario: Create a new L2VPN
+    Given I have loaded the "l2vpn/two-routers.json" L2VPN request
+    Given The client executes POST with a L2VPN payload on EseApiController path "/protected/l2vpn/new"
+    When The client receives a response from EseApiController
+    Then The client receives a EseApiController response status code of 200
+    And The EseApiController response is a valid L2VPN object
+    And The EseApiController response L2VPN object's meta username property matches "anonymous"
+
+  Scenario: Get the l2VPN of connection ID "XBYZ"
+    Given The client executes "GET" on EseApiController path "/api/l2vpn/get/XBYZ"
     When The client receives a response from EseApiController
     Then The client receives a EseApiController response status code of 200
     And The EseApiController response is a valid L2VPN object
@@ -25,12 +33,6 @@ Feature: EseApiController Endpoints for l2VPNs
 #    Then The client receives a EseApiController response status code of 200
 #    And The EseApiController response is a valid ValidationResponse object
 
-  Scenario: Create a new L2VPN
-    Given The client executes POST with a L2VPN payload on EseApiController path "/protected/l2vpn/new"
-    When The client receives a response from EseApiController
-    Then The client receives a EseApiController response status code of 200
-    And The EseApiController response is a valid L2VPN object
-    And The EseApiController response L2VPN object's meta username property matches "test-user"
 
 #  Scenario: Replace an L2VPN (Not implemented yet)
 #    Given The client executes PUT with a L2VPN payload on EseApiController path "/api/l2vpn/replace"


### PR DESCRIPTION
### Description

modify ESE tests to use actual OSCARS logic; re-use L2VPN JSON steps
added some JsonSetters so that we can deserialize the objects we serialize 

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [x] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [x] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
