### PR TITLE
feat: [OS-641] projectId now a set instead of a single string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 > Sep 2025
 - OS-617 defensive programming against topo NPE 
 - OS-618 try to stop sending null values to NSO
+- OS-640 multiple project ids per connection
 
 ### 1.2.32
 > Sep 2025

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 - OS-617 defensive programming against topo NPE 
 - OS-618 try to stop sending null values to NSO
 - OS-590 de-mockify EseApiController tests
+- OS-640 multiple project ids per connection
 
 ### 1.2.32
 > Sep 2025

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 > Sep 2025
 - OS-617 defensive programming against topo NPE 
 - OS-618 try to stop sending null values to NSO
+- OS-590 de-mockify EseApiController tests
 
 ### 1.2.32
 > Sep 2025

--- a/backend/src/main/java/net/es/oscars/model/L2VPN.java
+++ b/backend/src/main/java/net/es/oscars/model/L2VPN.java
@@ -13,7 +13,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Jacksonized
 @Builder
@@ -115,8 +117,9 @@ public class L2VPN {
         @JsonFormat(shape = JsonFormat.Shape.NUMBER, timezone = "UTC")
         private Instant lastModified = Instant.now();
 
+        @Builder.Default
         @Schema(description = "Project identifier. This is an external ID", nullable = true)
-        protected String projectId;
+        protected Set<String> projectId = new HashSet<>();
 
     }
 

--- a/backend/src/main/java/net/es/oscars/model/L2VPN.java
+++ b/backend/src/main/java/net/es/oscars/model/L2VPN.java
@@ -119,7 +119,7 @@ public class L2VPN {
 
         @Builder.Default
         @Schema(description = "Project identifier. This is an external ID", nullable = true)
-        protected Set<String> projectId = new HashSet<>();
+        protected Set<String> projectIds = new HashSet<>();
 
     }
 

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiMappingService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiMappingService.java
@@ -560,8 +560,8 @@ public class NsiMappingService {
         p2p.getParameter().add(tvt);
 
         // add multiple project ids
-        if (c.getProjectId() != null) {
-            for (String projectId : c.getProjectId()) {
+        if (c.getProjectIds() != null) {
+            for (String projectId : c.getProjectIds()) {
                 TypeValueType tvtProjectId = new TypeValueType();
                 tvt.setType("projectId");
                 tvt.setValue(projectId);

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiMappingService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiMappingService.java
@@ -559,11 +559,14 @@ public class NsiMappingService {
         tvt.setValue(mapping.getOscarsConnectionId());
         p2p.getParameter().add(tvt);
 
+        // add multiple project ids
         if (c.getProjectId() != null) {
-            TypeValueType tvtProjectId = new TypeValueType();
-            tvt.setType("projectId");
-            tvt.setValue(c.getProjectId());
-            p2p.getParameter().add(tvtProjectId);
+            for (String projectId : c.getProjectId()) {
+                TypeValueType tvtProjectId = new TypeValueType();
+                tvt.setType("projectId");
+                tvt.setValue(projectId);
+                p2p.getParameter().add(tvtProjectId);
+            }
         }
 
         String srcStp = mapping.getSrc();

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
@@ -1038,11 +1038,11 @@ public class NsiService {
 
         List<String> include = new ArrayList<>();
         ConnectionMode connectionMode = ConnectionMode.NEW;
-        String projectId = null;
+        Set<String> projectId = new HashSet<>();
 
         for (TypeValueType tvt : p2ps.getParameter()) {
             if (tvt.getType().equals("projectId") && tvt.getValue() != null && !tvt.getValue().isEmpty()) {
-                projectId = tvt.getValue();
+                projectId.add(tvt.getValue());
             }
         }
 

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiService.java
@@ -1122,7 +1122,7 @@ public class NsiService {
                     .tags(tags)
                     .connection_mtu(9000)
                     .username("nsi")
-                    .projectId(projectId)
+                    .projectIds(projectId)
                     .build();
             try {
                 String pretty = jacksonObjectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(simpleConnection);

--- a/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
+++ b/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
@@ -2,7 +2,6 @@ package net.es.oscars.resv.ent;
 
 import com.fasterxml.jackson.annotation.*;
 
-import io.micrometer.common.lang.Nullable;
 import jakarta.persistence.*;
 import lombok.*;
 import net.es.oscars.resv.enums.*;
@@ -38,7 +37,7 @@ public class Connection {
                       @JsonProperty("archived") Archived archived,
                       @JsonProperty("connection_mtu") @NonNull Integer connection_mtu,
                       @JsonProperty("last_modified") @NonNull Integer last_modified,
-                      @JsonProperty("projectId") Set<String> projectId) {
+                      @JsonProperty("projectId") Set<String> projectIds) {
         this.connectionId = connectionId;
         this.phase = phase;
         this.mode = mode;
@@ -55,7 +54,7 @@ public class Connection {
         this.connection_mtu = connection_mtu;
         this.last_modified = last_modified;
 
-        this.projectId = projectId;
+        this.projectIds = projectIds;
     }
 
 
@@ -157,7 +156,7 @@ public class Connection {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @ElementCollection
-    private Set<String> projectId;
+    private Set<String> projectIds;
 
     @Override
     public final boolean equals(Object o) {

--- a/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
+++ b/backend/src/main/java/net/es/oscars/resv/ent/Connection.java
@@ -10,6 +10,7 @@ import org.hibernate.proxy.HibernateProxy;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -37,7 +38,7 @@ public class Connection {
                       @JsonProperty("archived") Archived archived,
                       @JsonProperty("connection_mtu") @NonNull Integer connection_mtu,
                       @JsonProperty("last_modified") @NonNull Integer last_modified,
-                      @JsonProperty("projectId") String projectId) {
+                      @JsonProperty("projectId") Set<String> projectId) {
         this.connectionId = connectionId;
         this.phase = phase;
         this.mode = mode;
@@ -155,7 +156,8 @@ public class Connection {
     public ConnectionSouthbound southbound;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private String projectId;
+    @ElementCollection
+    private Set<String> projectId;
 
     @Override
     public final boolean equals(Object o) {

--- a/backend/src/main/java/net/es/oscars/resv/svc/ConnUtils.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ConnUtils.java
@@ -220,7 +220,7 @@ public class ConnUtils {
                 .tags(new ArrayList<>())
                 .connection_mtu(in.getConnection_mtu())
                 .serviceId(in.getServiceId())
-                .projectId(in.getProjectId())
+                .projectIds(in.getProjectIds())
                 .build();
 
         log.debug("setting a held connection " + c.getConnectionId());
@@ -468,7 +468,7 @@ public class ConnUtils {
                 .fixtures(fixtures)
                 .junctions(junctions)
                 .pipes(pipes)
-                .projectId(c.getProjectId())
+                .projectIds(c.getProjectIds())
                 .build());
     }
 

--- a/backend/src/main/java/net/es/oscars/resv/svc/conversions/L2VPNConversions.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/conversions/L2VPNConversions.java
@@ -184,7 +184,7 @@ public class L2VPNConversions {
                 .username(c.getUsername())
                 .trackingId(c.getServiceId())
                 .orchId(null)
-                .projectId(c.getProjectId())
+                .projectIds(c.getProjectIds())
                 .build();
     }
 
@@ -345,8 +345,8 @@ public class L2VPNConversions {
         }
 
         Set<String> projectId = new HashSet<>();
-        if (l2VPNRequest.getMeta() != null && l2VPNRequest.getMeta().getProjectId() != null) {
-            projectId = l2VPNRequest.getMeta().getProjectId();
+        if (l2VPNRequest.getMeta() != null && l2VPNRequest.getMeta().getProjectIds() != null) {
+            projectId = l2VPNRequest.getMeta().getProjectIds();
         }
 
         return SimpleConnection.builder()
@@ -364,7 +364,7 @@ public class L2VPNConversions {
                 .fixtures(fixtures)
                 .junctions(new ArrayList<>(junctions))
                 .pipes(pipes)
-                .projectId(projectId)
+                .projectIds(projectId)
                 .build();
 
     }

--- a/backend/src/main/java/net/es/oscars/resv/svc/conversions/L2VPNConversions.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/conversions/L2VPNConversions.java
@@ -344,9 +344,9 @@ public class L2VPNConversions {
             }
         }
 
-        String projectId = null;
+        Set<String> projectId = new HashSet<>();
         if (l2VPNRequest.getMeta() != null && l2VPNRequest.getMeta().getProjectId() != null) {
-            l2VPNRequest.getMeta().getProjectId();
+            projectId = l2VPNRequest.getMeta().getProjectId();
         }
 
         return SimpleConnection.builder()

--- a/backend/src/main/java/net/es/oscars/topo/beans/v2/Bandwidth.java
+++ b/backend/src/main/java/net/es/oscars/topo/beans/v2/Bandwidth.java
@@ -2,6 +2,8 @@ package net.es.oscars.topo.beans.v2;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -21,6 +23,13 @@ public class Bandwidth {
 
     @NonNull
     private Integer physical;
+
+    private Double utilization;
+
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    public void setUtilization(Double utilization) {
+        this.utilization = utilization;
+    }
 
     @JsonGetter
     private Double utilization() {

--- a/backend/src/main/java/net/es/oscars/topo/beans/v2/EdgePort.java
+++ b/backend/src/main/java/net/es/oscars/topo/beans/v2/EdgePort.java
@@ -14,6 +14,13 @@ import java.util.Set;
 @AllArgsConstructor
 @NoArgsConstructor
 public class EdgePort {
+    private String urn;
+
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    public void setUrn(String urn) {
+        this.urn = urn;
+    }
+
     @JsonGetter("urn")
     public String getUrn() {
         return device+":"+name;

--- a/backend/src/main/java/net/es/oscars/topo/beans/v2/VlanAvailability.java
+++ b/backend/src/main/java/net/es/oscars/topo/beans/v2/VlanAvailability.java
@@ -1,6 +1,9 @@
 package net.es.oscars.topo.beans.v2;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.sun.xml.xsom.impl.scd.Step;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,6 +21,19 @@ import java.util.Set;
 public class VlanAvailability {
 
     private Set<IntRange> ranges;
+    private String expression;
+    private List<List<Integer>> tuples;
+
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    public void setExpression(String expression) {
+        this.expression = expression;
+    }
+
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    public void setTuples(List<List<Integer>> tuples) {
+        this.tuples = tuples;
+    }
+
 
     @JsonGetter("expression")
     private String asExpression() {

--- a/backend/src/main/java/net/es/oscars/web/simple/SimpleConnection.java
+++ b/backend/src/main/java/net/es/oscars/web/simple/SimpleConnection.java
@@ -11,6 +11,7 @@ import net.es.oscars.resv.enums.State;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Builder
 @Data
@@ -41,6 +42,6 @@ public class SimpleConnection {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     protected Validity validity;
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    protected String projectId;
+    protected Set<String> projectId;
 
 }

--- a/backend/src/main/java/net/es/oscars/web/simple/SimpleConnection.java
+++ b/backend/src/main/java/net/es/oscars/web/simple/SimpleConnection.java
@@ -42,6 +42,6 @@ public class SimpleConnection {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     protected Validity validity;
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    protected Set<String> projectId;
+    protected Set<String> projectIds;
 
 }

--- a/backend/src/test/java/net/es/oscars/cuke/CucumberWorld.java
+++ b/backend/src/test/java/net/es/oscars/cuke/CucumberWorld.java
@@ -1,5 +1,6 @@
 package net.es.oscars.cuke;
 
+import net.es.oscars.model.L2VPN;
 import net.es.oscars.resv.beans.PeriodBandwidth;
 import net.es.oscars.resv.ent.Design;
 import net.es.oscars.resv.ent.EroHop;
@@ -26,6 +27,8 @@ public class CucumberWorld {
     Map<String, TopoUrn> topoBaseline ;
     Design design;
     Map<EroDirection, List<EroHop>> pipeEros;
+
+    L2VPN l2vpn;
 
 
     public void expectException() {

--- a/backend/src/test/java/net/es/oscars/cuke/EseApiControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/EseApiControllerSteps.java
@@ -8,7 +8,6 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import io.cucumber.java.hu.Ha;
 import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.BackendTestConfiguration;
 import net.es.oscars.app.Startup;
@@ -258,7 +257,7 @@ public class EseApiControllerSteps extends CucumberSteps {
             .meta(
                 L2VPN.Meta.builder()
                     .username("test-user")
-                    .projectId(projectIds)
+                    .projectIds(projectIds)
                     .build()
             )
             .schedule(
@@ -459,7 +458,7 @@ public class EseApiControllerSteps extends CucumberSteps {
             .description("test description")
             .connection_mtu(10000)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
-            .projectId(projectIds)
+            .projectIds(projectIds)
             .build();
     }
 

--- a/backend/src/test/java/net/es/oscars/cuke/EseApiControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/EseApiControllerSteps.java
@@ -24,6 +24,10 @@ import net.es.oscars.resv.ent.Held;
 import net.es.oscars.resv.enums.*;
 import net.es.oscars.resv.svc.ConnService;
 import net.es.oscars.resv.svc.L2VPNService;
+import net.es.oscars.topo.beans.TopoException;
+import net.es.oscars.topo.beans.Topology;
+import net.es.oscars.topo.pop.TopoPopulator;
+import net.es.oscars.topo.svc.TopologyStore;
 import net.es.oscars.web.beans.BandwidthAvailabilityResponse;
 import net.es.oscars.web.beans.ConnectionFilter;
 import net.es.oscars.web.beans.v2.L2VPNList;
@@ -39,6 +43,7 @@ import org.springframework.http.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.*;
 
@@ -72,10 +77,13 @@ public class EseApiControllerSteps extends CucumberSteps {
     @MockitoBean
     private Authentication authentication;
 
-    @Autowired
-    private MockSimpleConnectionHelper helper;
-
     private ResponseEntity<String> response;
+
+    @Autowired
+    private TopoPopulator topoPopulator;
+
+    @Autowired
+    private TopologyStore topologyStore;
 
     @MockitoBean
     L2VPNService l2VPNService;
@@ -96,12 +104,19 @@ public class EseApiControllerSteps extends CucumberSteps {
         mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
 
+        try {
+            Topology t = topoPopulator.loadTopology("topo/esnet.json");
+            topologyStore.replaceTopology(t);
+            startup.setInStartup(false);
+        } catch (TopoException | IOException e) {
+            throw new RuntimeException(e);
+        }
+
         // Reset stuff
         clear();
 
         // Setup mock data sources
         MockitoAnnotations.openMocks(this);
-        setupDatasources();
 
         // Mock startup
         startup.setInStartup(false);
@@ -109,189 +124,6 @@ public class EseApiControllerSteps extends CucumberSteps {
 
     private void clear() {
         response = null;
-    }
-
-    private void setupDatasources() throws Exception {
-//        setupMockL2VPNConversions();
-        setupMockConnService();
-        setupMockL2VPNService();
-        setupMockUsernameGetter();
-    }
-
-//    private void setupMockL2VPNConversions() throws Exception {
-//        Mockito
-//            .when(
-//                L2VPNConversions.fromConnection(Mockito.any(Connection.class))
-//            )
-//            .thenReturn(
-//                generateMockL2VPN()
-//            );
-//    }
-
-    private void setupMockConnService() throws Exception {
-        connSvc = Mockito.mock(ConnService.class);
-        Connection mockConn = generateMockConnection();
-        Optional<Connection> mockConnOpt = Optional.of(mockConn);
-
-        // Mock ConnService.findConnection()
-        // ...requires ConnService.held data property (Map<String, Connection>)
-        connSvc.setHeld(Map.of("ABCD", mockConn));
-        Mockito
-            .doReturn(mockConnOpt).when(
-            connSvc
-        ).findConnection(Mockito.anyString());
-    }
-
-    private void setupMockL2VPNService() throws Exception {
-        l2VPNService = Mockito.mock(L2VPNService.class);
-
-        l2VPNService.setConnSvc(connSvc);
-
-        // TODO: Setup mock handlers for L2VPNService class methods
-        // Mock L2VPNService.get()
-        L2VPN mockL2VPN = generateMockL2VPN();
-
-        Mockito
-            .doReturn(
-                mockL2VPN
-            )
-            .when(
-                l2VPNService
-            ).get(
-                Mockito.anyString()
-            );
-
-        // Mock L2VPNService.list()
-        List<L2VPN> mockL2VPNs = new ArrayList<>();
-        mockL2VPNs.add(mockL2VPN);
-
-        L2VPNList mockL2VPNList = L2VPNList.builder()
-            .page(1)
-            .sizePerPage(1)
-            .totalSize(1)
-            .l2vpns(mockL2VPNs)
-            .build();
-
-        Mockito
-            .when(
-                l2VPNService.list(
-                    Mockito.any(ConnectionFilter.class)
-                )
-            )
-            .thenReturn(
-                mockL2VPNList
-            );
-
-        // Mock L2VPNService.create()
-        Mockito
-            .when(
-                l2VPNService.createOrReplace(Mockito.any(L2VPN.class))
-            )
-            .thenReturn(
-                mockL2VPN
-            );
-        // Mock L2VPNService.bwAvailability()
-        Mockito
-            .when(
-                l2VPNService.bwAvailability(Mockito.any(L2VPN.class))
-            )
-            .thenReturn(
-                BandwidthAvailabilityResponse.builder()
-                    .available(1)
-                    .baseline(1)
-                    .build()
-            );
-        Mockito
-                .when(
-                        l2VPNService.validate(Mockito.any(L2VPN.class), Mockito.any(ConnectionMode.class))
-                )
-                .thenReturn(
-                        ValidationResponse.builder()
-                                .valid(true)
-                                .message("OK")
-                                .build()
-                );
-        controller.setL2VPNService(l2VPNService);
-    }
-
-    private L2VPN generateMockL2VPN() {
-        List<Bundle> mockBundles = new ArrayList<>();
-        List<Endpoint> mockEndpoints = new ArrayList<>();
-
-        mockBundles.add(
-            Bundle.builder()
-                .id(1L)
-                .name("TestBundle1")
-                .a("test1-cr6")
-                .z("test2-cr6")
-                .constraints(
-                    Bundle.Constraints.builder()
-                        .build()
-                )
-                .build()
-        );
-
-        mockEndpoints.add(
-            Endpoint.builder()
-                .id(1L)
-                .device("test1-cr6")
-                .port("1/1/c32/1")
-                .vlan(122)
-                .tagged(false)
-                .build()
-        );
-        mockEndpoints.add(
-            Endpoint.builder()
-                .id(2L)
-                .device("test2-cr6")
-                .port("1/1/c32/2")
-                .vlan(122)
-                .tagged(false)
-                .build()
-        );
-        return L2VPN.builder()
-            .id(1L)
-            .name("TEST")
-            .meta(
-                L2VPN.Meta.builder()
-                    .username("test-user")
-                    .projectId("ABCD-1234-EFGH-5678")
-                    .build()
-            )
-            .schedule(
-                Interval.builder()
-                    .build()
-            )
-            .status(
-                L2VPN.Status.builder()
-                    .build()
-            )
-            .qos(
-                L2VPN.Qos.builder()
-                    .build()
-            )
-            .tech(
-                L2VPN.Tech.builder()
-                    .build()
-            )
-            .bundles(mockBundles)
-            .endpoints(mockEndpoints)
-            .build();
-    }
-
-    private void setupMockUsernameGetter() throws Exception {
-        usernameGetter = Mockito.mock(UsernameGetter.class);
-
-        // Mock UsernameGetter.username()
-        Mockito
-            .doReturn("test-user")
-            .when(
-                usernameGetter
-
-            )
-            .username(Mockito.any());
-
-        controller.setUsernameGetter(usernameGetter);
     }
 
     @Given("The client executes {string} on EseApiController path {string}")
@@ -354,7 +186,7 @@ public class EseApiControllerSteps extends CucumberSteps {
             headers.setContentType(MediaType.APPLICATION_JSON);
             headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
 
-            L2VPN requestPayload = generateMockL2VPN();
+            L2VPN requestPayload = world.l2vpn;
 
             String payload = mapper.writeValueAsString(requestPayload);
 
@@ -425,37 +257,6 @@ public class EseApiControllerSteps extends CucumberSteps {
         assert responseObject != null;
     }
 
-    private Connection generateMockConnection() {
-        return Connection.builder()
-            .id(1L)
-            .held( // Required, or /protected/modify/description result will become an HTTP 500 Internal Server Error
-                Held.builder()
-                    .connectionId("ABCD")
-                    .cmp(
-                        Components.builder()
-                            .id(1L)
-                            .fixtures(new ArrayList<>())
-                            .junctions(new ArrayList<>())
-                            .pipes(new ArrayList<>())
-                            .build()
-                    )
-                    .expiration(Instant.now().plusSeconds(60 * 20)) // 20 minutes from now
-                    .schedule(helper.createValidSchedule())
-                    .build()
-            )
-            .connectionId("ABCD")
-            .phase(Phase.HELD)
-            .mode(BuildMode.AUTOMATIC)
-            .state(State.WAITING)
-            .deploymentState(DeploymentState.UNDEPLOYED)
-            .deploymentIntent(DeploymentIntent.SHOULD_BE_DEPLOYED)
-            .username("test")
-            .description("test description")
-            .connection_mtu(10000)
-            .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
-            .projectId("ABCD-1234-EFGH-5678")
-            .build();
-    }
 
     @And("The EseApiController response is a valid ValidationResponse object")
     public void theEseApiControllerResponseIsAValidValidationResponseObject() throws JsonProcessingException {

--- a/backend/src/test/java/net/es/oscars/cuke/EseApiControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/EseApiControllerSteps.java
@@ -8,6 +8,7 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import io.cucumber.java.hu.Ha;
 import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.BackendTestConfiguration;
 import net.es.oscars.app.Startup;

--- a/backend/src/test/java/net/es/oscars/cuke/EseApiControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/EseApiControllerSteps.java
@@ -8,6 +8,7 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import io.cucumber.java.hu.Ha;
 import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.BackendTestConfiguration;
 import net.es.oscars.app.Startup;
@@ -249,13 +250,15 @@ public class EseApiControllerSteps extends CucumberSteps {
                 .tagged(false)
                 .build()
         );
+        Set<String> projectIds = new HashSet<>();
+        projectIds.add("ABCD-1234-EFGH-5678");
         return L2VPN.builder()
             .id(1L)
             .name("TEST")
             .meta(
                 L2VPN.Meta.builder()
                     .username("test-user")
-                    .projectId("ABCD-1234-EFGH-5678")
+                    .projectId(projectIds)
                     .build()
             )
             .schedule(
@@ -426,6 +429,9 @@ public class EseApiControllerSteps extends CucumberSteps {
     }
 
     private Connection generateMockConnection() {
+        Set<String> projectIds = new HashSet<>();
+        projectIds.add("ABCD-1234-EFGH-5678");
+
         return Connection.builder()
             .id(1L)
             .held( // Required, or /protected/modify/description result will become an HTTP 500 Internal Server Error
@@ -453,7 +459,7 @@ public class EseApiControllerSteps extends CucumberSteps {
             .description("test description")
             .connection_mtu(10000)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
-            .projectId("ABCD-1234-EFGH-5678")
+            .projectId(projectIds)
             .build();
     }
 

--- a/backend/src/test/java/net/es/oscars/cuke/HoldControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/HoldControllerSteps.java
@@ -124,7 +124,7 @@ public class HoldControllerSteps {
             .description("test description")
             .connection_mtu(10000)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
-            .projectId(projectIds)
+            .projectIds(projectIds)
             .build();
     }
     private void setupMockConnSvc() throws Exception {
@@ -189,7 +189,7 @@ public class HoldControllerSteps {
                 invocation -> {
                     Pair<SimpleConnection, Connection> mockResult = null;
                     SimpleConnection s = (SimpleConnection) invocation.getArgument(0);
-                    if (s.getProjectId() == null) {
+                    if (s.getProjectIds() == null) {
                         mockResult = mockHoldConnection;
                     } else {
                         mockResult = mockHoldConnectionWithProjectId;

--- a/backend/src/test/java/net/es/oscars/cuke/HoldControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/HoldControllerSteps.java
@@ -110,6 +110,9 @@ public class HoldControllerSteps {
         return generateMockConnection(null);
     }
     private Connection generateMockConnection(String projectId) {
+        Set<String> projectIds = new HashSet<>();
+        projectIds.add(projectId);
+
         return Connection.builder()
             .connectionId("ABCD")
             .phase(Phase.HELD)
@@ -121,7 +124,7 @@ public class HoldControllerSteps {
             .description("test description")
             .connection_mtu(10000)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
-            .projectId(null)
+            .projectId(projectIds)
             .build();
     }
     private void setupMockConnSvc() throws Exception {

--- a/backend/src/test/java/net/es/oscars/cuke/L2vpnSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/L2vpnSteps.java
@@ -100,6 +100,7 @@ public class L2vpnSteps extends CucumberSteps {
         // modify the schedule
         request.getSchedule().setBeginning(Instant.now().plus(1, ChronoUnit.MINUTES));
         request.getSchedule().setEnding(Instant.now().plus(30, ChronoUnit.MINUTES));
+        world.l2vpn = request;
     }
 
     @When("I validate the new L2VPN request")

--- a/backend/src/test/java/net/es/oscars/cuke/MockSimpleConnectionHelper.java
+++ b/backend/src/test/java/net/es/oscars/cuke/MockSimpleConnectionHelper.java
@@ -226,6 +226,8 @@ public class MockSimpleConnectionHelper {
 
         int minMtuDefault = this.connService.getMinMtu();
         log.info("minMtuDefault: " + minMtuDefault);
+        Set<String> projectIds = new HashSet<>();
+        projectIds.add(projectId);
 
         return SimpleConnection.builder()
             .username(      this.userName )
@@ -245,7 +247,7 @@ public class MockSimpleConnectionHelper {
             .pipes(         this.connectionPipes)
             .last_modified( this.beginTime )
             .validity( this.createTrueValidity() )
-            .projectId(projectId)
+            .projectId(projectIds)
             .build();
     }
 
@@ -348,6 +350,8 @@ public class MockSimpleConnectionHelper {
 
         // Mock held connections.
         // @TODO: Must be length zero or more for validation to pass?
+        Set<String> projectIds = new HashSet<>();
+        projectIds.add(this.projectId);
 
         // ...add mock held Connection entries.
         Connection mockConnection = Connection.builder()
@@ -364,7 +368,7 @@ public class MockSimpleConnectionHelper {
             .deploymentState(DeploymentState.UNDEPLOYED)
             .deploymentIntent(DeploymentIntent.SHOULD_BE_UNDEPLOYED)
             .last_modified(this.beginTime)
-            .projectId(this.projectId)
+            .projectId(projectIds)
             .build();
         this.held.put(mockConnection.getConnectionId(), mockConnection);
 
@@ -491,6 +495,9 @@ public class MockSimpleConnectionHelper {
         );
     }
     public Connection generateMockConnection(String mockConnectionId, Phase phase, BuildMode buildMode, State state, DeploymentState deploymentState, DeploymentIntent deploymentIntent, int connection_mtu, String projectId) {
+        Set<String> projectIds = new HashSet<>();
+        projectIds.add(projectId);
+
         return Connection.builder()
             .id(1L)
             .held( // Required, or /protected/modify/description result will become an HTTP 500 Internal Server Error
@@ -518,7 +525,7 @@ public class MockSimpleConnectionHelper {
             .description("test description")
             .connection_mtu(connection_mtu)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
-            .projectId(projectId)
+            .projectId(projectIds)
             .build();
     }
 }

--- a/backend/src/test/java/net/es/oscars/cuke/MockSimpleConnectionHelper.java
+++ b/backend/src/test/java/net/es/oscars/cuke/MockSimpleConnectionHelper.java
@@ -247,7 +247,7 @@ public class MockSimpleConnectionHelper {
             .pipes(         this.connectionPipes)
             .last_modified( this.beginTime )
             .validity( this.createTrueValidity() )
-            .projectId(projectIds)
+            .projectIds(projectIds)
             .build();
     }
 
@@ -368,7 +368,7 @@ public class MockSimpleConnectionHelper {
             .deploymentState(DeploymentState.UNDEPLOYED)
             .deploymentIntent(DeploymentIntent.SHOULD_BE_UNDEPLOYED)
             .last_modified(this.beginTime)
-            .projectId(projectIds)
+            .projectIds(projectIds)
             .build();
         this.held.put(mockConnection.getConnectionId(), mockConnection);
 
@@ -525,7 +525,7 @@ public class MockSimpleConnectionHelper {
             .description("test description")
             .connection_mtu(connection_mtu)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
-            .projectId(projectIds)
+            .projectIds(projectIds)
             .build();
     }
 }

--- a/backend/src/test/java/net/es/oscars/cuke/NsiProviderSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/NsiProviderSteps.java
@@ -39,7 +39,6 @@ import io.cucumber.java.en.When;
 import jakarta.xml.soap.MessageFactory;
 import jakarta.xml.soap.SOAPBody;
 import jakarta.xml.soap.SOAPMessage;
-import kotlin.NotImplementedError;
 import lombok.extern.slf4j.Slf4j;
 import net.es.nsi.lib.soap.gen.nsi_2_0.connection.types.ReservationStateEnumType;
 import net.es.nsi.lib.soap.gen.nsi_2_0.connection.types.ReserveResponseType;
@@ -347,8 +346,8 @@ public class NsiProviderSteps extends CucumberSteps {
     public void the_NSI_connection_has_a_projectId() {
         try {
             connService.getHeld().forEach((id, conn) -> {
-                log.info("Connection {} has projectId {}", id, conn.getProjectId());
-                assert conn.getProjectId() != null;
+                log.info("Connection {} has projectId {}", id, conn.getProjectIds());
+                assert conn.getProjectIds() != null;
             });
         } catch (Exception e) {
             world.add(e);

--- a/backend/src/test/java/net/es/oscars/cuke/NsiServiceSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/NsiServiceSteps.java
@@ -876,13 +876,13 @@ public class NsiServiceSteps extends CucumberSteps {
     @Then("the connection does not have a projectId value")
     public void the_connection_does_not_have_a_projectId_value() {
         assert mockConnection != null;
-        assert mockConnection.getProjectIds() == null || !mockConnection.getProjectIds().isEmpty();
+        assert mockConnection.getProjectIds() == null || mockConnection.getProjectIds().isEmpty();
     }
 
     @Then("The connection has a projectId value")
     public void The_connection_has_a_projectId_value() {
         assert mockConnection != null;
-        assert mockConnection.getProjectIds() != null;
+        assert mockConnection.getProjectIds() != null && !mockConnection.getProjectIds().isEmpty();
     }
     // * NSI Release steps END *
 }

--- a/backend/src/test/java/net/es/oscars/cuke/NsiServiceSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/NsiServiceSteps.java
@@ -876,13 +876,13 @@ public class NsiServiceSteps extends CucumberSteps {
     @Then("the connection does not have a projectId value")
     public void the_connection_does_not_have_a_projectId_value() {
         assert mockConnection != null;
-        assert mockConnection.getProjectId() == null || !mockConnection.getProjectId().isEmpty();
+        assert mockConnection.getProjectIds() == null || !mockConnection.getProjectIds().isEmpty();
     }
 
     @Then("The connection has a projectId value")
     public void The_connection_has_a_projectId_value() {
         assert mockConnection != null;
-        assert mockConnection.getProjectId() != null;
+        assert mockConnection.getProjectIds() != null;
     }
     // * NSI Release steps END *
 }

--- a/backend/src/test/java/net/es/oscars/cuke/NsiServiceSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/NsiServiceSteps.java
@@ -876,7 +876,7 @@ public class NsiServiceSteps extends CucumberSteps {
     @Then("the connection does not have a projectId value")
     public void the_connection_does_not_have_a_projectId_value() {
         assert mockConnection != null;
-        assert mockConnection.getProjectId() == null;
+        assert mockConnection.getProjectId() == null || !mockConnection.getProjectId().isEmpty();
     }
 
     @Then("The connection has a projectId value")

--- a/backend/src/test/java/net/es/oscars/cuke/TopoSearchControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/TopoSearchControllerSteps.java
@@ -142,7 +142,7 @@ public class TopoSearchControllerSteps {
             .description("test description")
             .connection_mtu(10000)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
-            .projectId(projectIds)
+            .projectIds(projectIds)
             .build();
     }
     private void setupMockConnSvc() throws Exception {

--- a/backend/src/test/java/net/es/oscars/cuke/TopoSearchControllerSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/TopoSearchControllerSteps.java
@@ -128,6 +128,9 @@ public class TopoSearchControllerSteps {
         controller.setConnRepo(connRepo);
     }
     private Connection generateMockConnection() {
+        Set<String> projectIds = new HashSet<>();
+        projectIds.add("ABCD-1234-EFGH-5678");
+
         return Connection.builder()
             .connectionId("ABCD")
             .phase(Phase.HELD)
@@ -139,7 +142,7 @@ public class TopoSearchControllerSteps {
             .description("test description")
             .connection_mtu(10000)
             .last_modified( ((Long) Instant.now().getEpochSecond()).intValue() )
-            .projectId("ABCD-1234-EFGH-5678")
+            .projectId(projectIds)
             .build();
     }
     private void setupMockConnSvc() throws Exception {

--- a/backend/src/test/resources/net/es/oscars/cuke/ese_api_controller.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/ese_api_controller.happy.feature
@@ -1,8 +1,16 @@
 @EseApiControllerSteps
 @EseApiControllerStepsHappy
 Feature: EseApiController Endpoints for l2VPNs
-  Scenario: Get the l2VPN of connection ID "ABCD"
-    Given The client executes "GET" on EseApiController path "/api/l2vpn/get/ABCD"
+  Scenario: Create a new L2VPN
+    Given I have loaded the "l2vpn/two-routers.json" L2VPN request
+    Given The client executes POST with a L2VPN payload on EseApiController path "/protected/l2vpn/new"
+    When The client receives a response from EseApiController
+    Then The client receives a EseApiController response status code of 200
+    And The EseApiController response is a valid L2VPN object
+    And The EseApiController response L2VPN object's meta username property matches "anonymous"
+
+  Scenario: Get the l2VPN of connection ID "XBYZ"
+    Given The client executes "GET" on EseApiController path "/api/l2vpn/get/XBYZ"
     When The client receives a response from EseApiController
     Then The client receives a EseApiController response status code of 200
     And The EseApiController response is a valid L2VPN object
@@ -25,12 +33,6 @@ Feature: EseApiController Endpoints for l2VPNs
 #    Then The client receives a EseApiController response status code of 200
 #    And The EseApiController response is a valid ValidationResponse object
 
-  Scenario: Create a new L2VPN
-    Given The client executes POST with a L2VPN payload on EseApiController path "/protected/l2vpn/new"
-    When The client receives a response from EseApiController
-    Then The client receives a EseApiController response status code of 200
-    And The EseApiController response is a valid L2VPN object
-    And The EseApiController response L2VPN object's meta username property matches "test-user"
 
 #  Scenario: Replace an L2VPN (Not implemented yet)
 #    Given The client executes PUT with a L2VPN payload on EseApiController path "/api/l2vpn/replace"


### PR DESCRIPTION
### Description

modify model, tests to allow for multiple projectIds per connection

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [ ] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [x] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
