### PR TITLE
fix: [OS-652][OS-653] multithreading performance, and DB error fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,10 @@
 # OSCARS Release Notes
+### 1.2.35
+> Nov 2025
+- OS-652 Commit on modify error
+- OS-653 Fix task scheduling stalls
+
+
 ### 1.2.34
 > Oct 2025
 - OS-632 ProjectId validation against ESDB

--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -97,10 +97,12 @@ pce.short-path-detour=6
 # how long to keep uncommitted reservations via REST API before expunging, in sec
 resv.timeout=900
 resv.minimum-duration=15
+resv.state-delay=3s
 
 # how long to keep uncommitted reservations via NSI SOAP API before expunging them, in sec
 
 nsi.queue-delay=500ms
+nsi.housekeeping-delay=60s
 nsi.resv-timeout=300
 nsi.key-store=config/nsi.jks
 nsi.key-store-type=JKS

--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -164,6 +164,8 @@ frontend.oauth-scope=openid
 # comma-separate more origin URLS as needed
 frontend.cors-origins=http://localhost:8181/
 
+sb.trigger-delay=500ms
+
 nso.vc-id-range=7000:7999
 nso.sdp-id-range=7000:7999
 nso.sap-qos-id-range=7000:7999

--- a/backend/config/application.properties
+++ b/backend/config/application.properties
@@ -100,7 +100,7 @@ resv.minimum-duration=15
 
 # how long to keep uncommitted reservations via NSI SOAP API before expunging them, in sec
 
-nsi.queue-interval-millisec=5000
+nsi.queue-delay=500ms
 nsi.resv-timeout=300
 nsi.key-store=config/nsi.jks
 nsi.key-store-type=JKS
@@ -181,7 +181,7 @@ nso.backoff-milliseconds=30000
 #   "disabled": skip synchronization
 #   "dry-run-only": only perform dry-run and log the output; (use a long sync-interval-millisec to avoid log spam)
 #   "sync": full NSO sync
-nso.sync=dry-run-only
+nso.sync=disabled
 nso.sync-interval-millisec=30000
 # sync properties for new feature END
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -14,7 +14,7 @@
     <groupId>net.es.oscars</groupId>
     <artifactId>backend</artifactId>
     <name>backend</name>
-    <version>1.2.34</version>
+    <version>1.2.35</version>
 
     <description>OSCARS backend</description>
     <properties>

--- a/backend/src/main/java/net/es/oscars/app/ScheduledTaskConfig.java
+++ b/backend/src/main/java/net/es/oscars/app/ScheduledTaskConfig.java
@@ -1,0 +1,16 @@
+package net.es.oscars.app;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class ScheduledTaskConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler (){
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(5);
+        return taskScheduler;
+    }
+}

--- a/backend/src/main/java/net/es/oscars/app/ScheduledTaskConfig.java
+++ b/backend/src/main/java/net/es/oscars/app/ScheduledTaskConfig.java
@@ -10,7 +10,7 @@ public class ScheduledTaskConfig {
     @Bean
     public ThreadPoolTaskScheduler taskScheduler (){
         ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
-        taskScheduler.setPoolSize(5);
+        taskScheduler.setPoolSize(10);
         return taskScheduler;
     }
 }

--- a/backend/src/main/java/net/es/oscars/nsi/ent/NsiConnectionEvent.java
+++ b/backend/src/main/java/net/es/oscars/nsi/ent/NsiConnectionEvent.java
@@ -32,6 +32,7 @@ public class NsiConnectionEvent {
     @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC")
     private Instant timestamp;
 
+    @Column(length = 1024)
     private String message;
     private int version;
 

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiAsyncQueue.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiAsyncQueue.java
@@ -1,8 +1,6 @@
 package net.es.oscars.nsi.svc;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import net.es.nsi.lib.soap.gen.nsi_2_0.connection.types.QueryType;
@@ -27,8 +25,14 @@ public class NsiAsyncQueue {
     private final NsiMappingService nsiMappingService;
     private final Startup startup;
 
+    @Getter
+    @Setter
+    private boolean disable = false;
+
+    @Getter
     public ConcurrentLinkedQueue<AsyncItem> queue = new ConcurrentLinkedQueue<>();
 
+    @Setter
     public AsyncCallback<String> processQueueHandler;
 
     public NsiAsyncQueue(NsiService nsiService, NsiMappingService nsiMappingService, Startup startup) {
@@ -66,13 +70,16 @@ public class NsiAsyncQueue {
             // log.info("application in startup or shutdown; skipping queue processing");
             return;
         }
-        // log.info("processing NSI async task queue");
+        // when we want to pause the queue processing during testing
+        if (disable) {
+            return;
+        }
 
+        // log.info("processing NSI async task queue");
         if (queue.isEmpty()) {
             // log.info("returning from empty queue");
             return;
         }
-
         try (ExecutorService executorService = Executors.newFixedThreadPool(1)) {
 
             Future<Results> future = asyncProcessQueue(executorService);

--- a/backend/src/main/java/net/es/oscars/nsi/svc/NsiAsyncQueue.java
+++ b/backend/src/main/java/net/es/oscars/nsi/svc/NsiAsyncQueue.java
@@ -15,6 +15,7 @@ import net.es.oscars.app.util.AsyncCallback;
 import net.es.oscars.nsi.ent.NsiMapping;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -81,6 +82,16 @@ public class NsiAsyncQueue {
         } catch (InterruptedException | ExecutionException e) {
             log.error(e.getLocalizedMessage(), e);
         }
+    }
+
+    @Scheduled(fixedDelayString = "${nsi.housekeeping-delay}")
+    @Transactional
+    public void nsiHousekeeping() {
+        if (startup.isInStartup() || startup.isInShutdown()) {
+            return;
+        }
+        log.info("NSI housekeeping");
+        nsiService.housekeeping();
     }
 
     public Future<Results> asyncProcessQueue(ExecutorService executorService)  throws InterruptedException, ExecutionException {

--- a/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
@@ -550,11 +550,12 @@ public class ConnService {
 
     @Transactional
     public ConnChangeResult commit(Connection c) throws NsoResvException, PCEException, ConnException {
-        log.info("committing " + c.getConnectionId());
+        log.info("committing {}", c.getConnectionId());
         ReentrantLock connLock = dbAccess.getConnLock();
         if (connLock.isLocked()) {
-            log.debug("connection lock already locked; will need to wait to complete commit");
+            log.debug("connection lock already locked; will need to wait to complete commit for {}", c.getConnectionId());
         }
+        log.debug("got connection lock, resuming commit for {}", c.getConnectionId());
         connLock.lock();
 
         Held h = c.getHeld();
@@ -578,7 +579,7 @@ public class ConnService {
 
 
         try {
-            log.info("removing from held " + c.getConnectionId());
+            log.info("removing from held {}", c.getConnectionId());
             held.remove(c.getConnectionId());
             // log.debug("got connection lock ");
             c.setPhase(Phase.RESERVED);

--- a/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
+++ b/backend/src/main/java/net/es/oscars/resv/svc/ConnService.java
@@ -611,6 +611,7 @@ public class ConnService {
 
                 oldScheduleId = existing.get().getReserved().getSchedule().getId();
                 connRepo.delete(existing.get());
+                archivedRepo.delete(existing.get().getArchived());
             }
 
             reservedFromHeld(c);

--- a/backend/src/main/java/net/es/oscars/sb/SouthboundPeriodicChecker.java
+++ b/backend/src/main/java/net/es/oscars/sb/SouthboundPeriodicChecker.java
@@ -45,9 +45,9 @@ public class SouthboundPeriodicChecker {
      * - Any connection's deployment intent does not match its deployment state
      *
      */
-    @Scheduled(fixedDelay = 3000)
+    @Scheduled(fixedDelayString = "${sb.trigger-delay}")
     @Transactional
-    public void buildOrDismantle() {
+    public void triggerSouthbound() {
         if (startup.isInStartup() || startup.isInShutdown()) {
             // log.info("application in startup or shutdown; skipping state transitions");
             return;

--- a/backend/src/main/java/net/es/oscars/sb/SouthboundPeriodicChecker.java
+++ b/backend/src/main/java/net/es/oscars/sb/SouthboundPeriodicChecker.java
@@ -53,12 +53,14 @@ public class SouthboundPeriodicChecker {
             return;
         }
 
+//        log.info("triggerSouthbound start");
+
         ReentrantLock connLock = dbAccess.getConnLock();
         boolean gotLock = connLock.tryLock();
         if (gotLock) {
+//            log.info("triggerSouthbound got connection lock");
             Set<Connection> shouldBeMadeUndeployed = new HashSet<>();
             Set<String> shouldBeFinished = new HashSet<>();
-
             Set<Connection> shouldBeDeployed = new HashSet<>();
 
 
@@ -81,7 +83,7 @@ public class SouthboundPeriodicChecker {
             // modify intents on connections
             for (Connection c: shouldBeDeployed)  {
                 if (c.getDeploymentIntent().equals(DeploymentIntent.SHOULD_BE_UNDEPLOYED)) {
-                    log.info("now set to should-be-deployed "+c.getConnectionId());
+                    log.info("now set to should-be-deployed {}", c.getConnectionId());
                     c.setDeploymentIntent(DeploymentIntent.SHOULD_BE_DEPLOYED);
                     connRepo.save(c);
                 }
@@ -89,7 +91,7 @@ public class SouthboundPeriodicChecker {
 
             for (Connection c: shouldBeMadeUndeployed)  {
                 if (c.getDeploymentIntent().equals(DeploymentIntent.SHOULD_BE_DEPLOYED)) {
-                    log.info("now set to should-be-undeployed "+c.getConnectionId());
+                    log.info("now set to should-be-undeployed {}", c.getConnectionId());
                     c.setDeploymentIntent(DeploymentIntent.SHOULD_BE_UNDEPLOYED);
                     connRepo.save(c);
                 }
@@ -112,7 +114,7 @@ public class SouthboundPeriodicChecker {
                 if (c.getPhase().equals(Phase.RESERVED) &&
                         c.getReserved() != null &&
                         c.getReserved().getSchedule().getBeginning().isBefore(Instant.now())) {
-                    log.info("it is not-deployed, and should-be - adding a queued job to BUILD: "+c.getConnectionId());
+                    log.info("it is not-deployed, and should-be - adding a queued job to BUILD: {}", c.getConnectionId());
                     c.setDeploymentState(DeploymentState.WAITING_TO_BE_DEPLOYED);
                     connRepo.save(c);
                     southboundQueuer.add(CommandType.BUILD, c.getConnectionId(), State.ACTIVE);
@@ -120,7 +122,7 @@ public class SouthboundPeriodicChecker {
             }
 
             for (Connection c : undeployThese) {
-                log.info("it is deployed, and should-not-be - adding a queued job to DISMANTLE: "+c.getConnectionId());
+                log.info("it is deployed, and should-not-be - adding a queued job to DISMANTLE: {}", c.getConnectionId());
                 // we allow connections in any phase to get undeployed
                 c.setDeploymentState(DeploymentState.WAITING_TO_BE_UNDEPLOYED);
                 connRepo.save(c);
@@ -132,7 +134,7 @@ public class SouthboundPeriodicChecker {
             }
 
             for (Connection c : redeployThese) {
-                log.info("needs to be redeployed - adding a queued job to REDEPLOY: "+c.getConnectionId());
+                log.info("needs to be redeployed - adding a queued job to REDEPLOY: {}", c.getConnectionId());
                 c.setDeploymentState(DeploymentState.WAITING_TO_BE_REDEPLOYED);
                 connRepo.save(c);
                 southboundQueuer.add(CommandType.REDEPLOY, c.getConnectionId(), State.ACTIVE);
@@ -140,9 +142,11 @@ public class SouthboundPeriodicChecker {
 
             // run the PSS queue
             southboundQueuer.process();
+//            log.info("triggerSouthbound releasing connection lock");
             connLock.unlock();
-
         }
+
+//        log.info("triggerSouthbound end");
     }
 
 

--- a/backend/src/main/java/net/es/oscars/soap/NsiProvider.java
+++ b/backend/src/main/java/net/es/oscars/soap/NsiProvider.java
@@ -49,8 +49,8 @@ public class NsiProvider implements ConnectionProviderPort {
         ReserveResponseType rrt = new ReserveResponseType();
         String nsiConnectionId = reserve.getConnectionId();
         if (nsiConnectionId == null || nsiConnectionId.isEmpty()) {
-            log.info("creating a new connectionId");
             nsiConnectionId = UUID.randomUUID().toString();
+            log.info("created a new nsiConnectionId {}", nsiConnectionId);
         }
 
         rrt.setConnectionId(nsiConnectionId);
@@ -78,6 +78,7 @@ public class NsiProvider implements ConnectionProviderPort {
                 .reserve(reserve)
                 .build();
         queue.add(asyncItem);
+        log.info("added reserve task to queue for {}", nsiConnectionId);
 
         nsiHeaderUtils.makeResponseHeader(header.value);
         return rrt;

--- a/backend/src/test/resources/net/es/oscars/cuke/nsi_provider.happy.feature
+++ b/backend/src/test/resources/net/es/oscars/cuke/nsi_provider.happy.feature
@@ -2,6 +2,8 @@
 @NsiProviderStepsHappy
 Feature: The NSI SOAP API provider endpoints (Happy)
     Scenario: An NSI connection is reserved without a projectId field
+        Given I clear the nsi queue
+        Given I clear all held reservations
         Given The NSI connection is queued for asynchronous reservation while not including a projectId
         Given The NSI queue size is 1
         When The NSI queue is processed
@@ -10,6 +12,8 @@ Feature: The NSI SOAP API provider endpoints (Happy)
         And The NSI provider encountered 0 errors
 
    Scenario: An NSI connection is reserved with a projectId field
+       Given I clear the nsi queue
+       Given I clear all held reservations
        Given The NSI connection is queued for asynchronous reservation while including a projectId
        Given The NSI queue size is 1
        When The NSI queue is processed
@@ -18,6 +22,8 @@ Feature: The NSI SOAP API provider endpoints (Happy)
        And The NSI provider encountered 0 errors
 
     Scenario: An NSI connection is reserved with a blank projectId field
+       Given I clear the nsi queue
+       Given I clear all held reservations
        Given The NSI connection is queued for asynchronous reservation while including a blank projectId
        Given The NSI queue size is 1
        When The NSI queue is processed
@@ -30,12 +36,13 @@ Feature: The NSI SOAP API provider endpoints (Happy)
         # Draft NSI CS protocol 2.1 v13 at https://redmine.ogf.org/attachments/286/draft-nsi-cs-protocol-2dot1-v13.pdf
         # See  https://gitlab.es.net/esnet/nsi-soap/-/blob/main/src/main/java/net/es/nsi/lib/soap/gen/nsi_2_0/connection/types/ReservationStateEnumType.java?ref_type=heads
 
-
         # NSI reserve() hold
+        Given I clear the nsi queue
+        Given I clear all held reservations
         Given The connection is not reserved yet
         When An NSI connection reserve is requested
         Then The latest connection event type is "RESERVE_RECEIVED"
-        Then The NSI queue is processed
+        When The NSI queue is processed
         Then The reservation state path was "RESERVE_CHECKING -> RESERVE_HELD"
 
         # NSI commit()

--- a/backend/src/test/resources/testing.properties
+++ b/backend/src/test/resources/testing.properties
@@ -47,6 +47,8 @@ otel.instrumentation.common.default-enabled=false
 otel.service.name=oscars-backend
 otel.service.version=1.2
 
+sb.trigger-delay=100ms
+
 # sync properties for new feature BEGIN  (OSCARS to NSO state synchronization)
 nso.sync=disabled
 nso.sync-interval-millisec=100
@@ -101,6 +103,9 @@ pss.min-mtu=1500
 resv.timeout=900
 resv.minimum-duration=15
 
+resv.state-delay=3s
+
+
 slack.enable=false
 slack.channel=none
 slack.token=none
@@ -115,6 +120,7 @@ sec.default-admin-password=oscars
 sec.jwt-secret=My Jwt Secret
 sec.secure=true
 
+nsi.housekeeping-delay=60s
 nsi.published-endpoint-url=http://localhost:8201/services/provider
 nsi.provider-nsa=urn:ogf:network:es.net:2013:nsa
 nsi.allowed-requesters=urn:ogf:network:sense-rm.es.net:2013:esnet


### PR DESCRIPTION
### Description

Adds Spring scheduling configuration to enable using more than one thread
Adds a few property knobs to customize various scheduling delays
Fixes a potential database duplicate row error when committing during a modify.
Increase the maximum event message length to 1024
Adjust NsiProvider tests around NsiAsyncQueue


### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [x] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [x] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
