### PR TITLE
feat: [OS-647] add ESDB data sync for bandwidth utilization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 - ESE-361 fix last modified date for L2VPN
 - OS-672 error when modifying VLAN ids
 - OS-670 add hard / soft cap parameter to NSI
+- OS-647 write utilized bandwidth back to ESDB
 
 ### 1.2.36
 > Dec 2025

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>net.es.topo.common</groupId>
             <artifactId>topo-common</artifactId>
-            <version>0.0.45</version>
+            <version>0.0.46</version>
         </dependency>
         <dependency>
             <groupId>net.es.nsi</groupId>

--- a/backend/src/main/java/net/es/oscars/dto/esdb/gql/GraphqlEsdbBandwidthUtilization.java
+++ b/backend/src/main/java/net/es/oscars/dto/esdb/gql/GraphqlEsdbBandwidthUtilization.java
@@ -1,0 +1,21 @@
+package net.es.oscars.dto.esdb.gql;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+public class GraphqlEsdbBandwidthUtilization {
+    private String id;
+    private String uuid;
+    private Integer bandwidth;
+    private String system;
+    private String remoteSystemId;
+    public Integer getId() {
+        return Integer.parseInt(id);
+    }
+
+    private GraphqlEsdbEquipmentInterface equipmentInterface = new GraphqlEsdbEquipmentInterface();
+
+}

--- a/backend/src/main/java/net/es/oscars/esdb/ESDBProxy.java
+++ b/backend/src/main/java/net/es/oscars/esdb/ESDBProxy.java
@@ -10,9 +10,12 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.app.props.EsdbProperties;
 import net.es.oscars.app.util.HeaderRequestInterceptor;
+import net.es.oscars.dto.esdb.gql.GraphqlEsdbBandwidthUtilization;
 import net.es.oscars.dto.esdb.gql.GraphqlEsdbOrganization;
 import net.es.oscars.dto.esdb.gql.GraphqlEsdbOrganizationType;
 import net.es.oscars.dto.esdb.gql.GraphqlEsdbVlan;
+import net.es.topo.common.dto.esdb.EsdbBwUtil;
+import net.es.topo.common.dto.esdb.EsdbBwUtilPayload;
 import net.es.topo.common.dto.esdb.EsdbVlan;
 import net.es.topo.common.dto.esdb.EsdbVlanPayload;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -126,6 +129,8 @@ public class ESDBProxy {
         return this.gqlVlanList(searchQuery, sortProperty, first, skip, null);
     }
 
+
+
     /**
      * Get ESDB organizations from ESDB using GraphQL filtered by org type uuid.
      * @return Returns a list of GraphqlEsdbOrganization objects from the GraphQL response.
@@ -171,6 +176,94 @@ public class ESDBProxy {
                 .toEntityList(GraphqlEsdbOrganizationType.class);
     }
 
+    /**
+     * Get all ESDB bandwidth utilizations from ESDB using GraphQL. Targets vlanList.
+     * @param search The search (string) parameter for vlanList.
+     * @param sortProperty The sortProperty (string) parameter for vlanList.
+     * @param first The first (int) parameter for vlanList.
+     * @param skip The skip (int) parameter for vlanList.
+     * @return Returns a list of EsdbVlan objects from the GraphQL response.
+     */
+    public List<EsdbBwUtil> gqlBwUtil(
+            @Null String search,
+            @Null String sortProperty,
+            @Null Integer first,
+            @Null Integer skip
+    ) {
+        List<EsdbBwUtil> results;
+
+        Map<String, Object> params = new HashMap<>();
+
+        if (search != null && !search.isEmpty()) {
+            params.put("search", search);
+        }
+        if (sortProperty != null && !sortProperty.isEmpty()) {
+            params.put("sortProperty", sortProperty);
+        }
+        if (first != null) {
+            params.put("first", first);
+        }
+        if (skip != null) {
+            params.put("skip", skip);
+        }
+
+        HttpSyncGraphQlClient graphQlClient = createGraphqlClient();
+
+        // Should return a List<EsdbBwUtil> in the "list" property
+        // Example response payload:
+        // {
+        //  "data": {
+        //    "bandwidthUtilizationList": {
+        //      "count": 1646,
+        //      "results": [
+        //        {
+        //          "id": "10943",
+        //          "uuid": "",
+        //          "system": "oscars",
+        //          "remote_system_id": "OSCARS asdf-zyzz",
+        //          "equipmentInterface": {
+        //            "id": "14117"
+        //          }
+        //        },
+        //        ...,
+        //      ]
+        //    }
+        //  }
+        // }
+
+        // See oscars/backend/src/main/resources/graphql-documents/vlanList.graphql
+        // Our GraphQL client can autoload by document name from the graphql-documents/ directory.
+        GraphQlClient.RequestSpec requestSpec = graphQlClient
+                .documentName("bandwidthUtilizationList");
+
+        if (!params.isEmpty()) {
+            requestSpec.variables(params);
+        }
+        ClientGraphQlResponse response = requestSpec.executeSync();
+
+        List<GraphqlEsdbBandwidthUtilization> bwUtilList = response
+                .field("bandwidthUtilizationList.results")
+                .toEntityList(GraphqlEsdbBandwidthUtilization.class);
+
+        results = new ArrayList<>(bwUtilList.size());
+        if (!bwUtilList.isEmpty()) {
+            log.info("ESDBProxy.gqlBwUtil() called. List of bwUtils has a size of {}", bwUtilList.size());
+            for (GraphqlEsdbBandwidthUtilization bwUtil : bwUtilList) {
+                EsdbBwUtil ebw = EsdbBwUtil.builder()
+                        .id(bwUtil.getId())
+                        .bandwidth(bwUtil.getBandwidth())
+                        .equipmentInterface(bwUtil.getEquipmentInterface().getId())
+                        .system(bwUtil.getSystem())
+                        .remoteSystemId(bwUtil.getRemoteSystemId())
+                        .build();
+                results.add(ebw);
+            }
+        } else {
+            log.warn("ESDBProxy.gqlBwUtil() called but none found in ESDB GraphQL response. Returning empty list.");
+        }
+
+        return results;
+    }
 
 
     /**
@@ -308,4 +401,19 @@ public class ESDBProxy {
         log.info("delete rest path: "+restPath);
         restTemplate.delete(restPath);
     }
+
+    public void createBandwidthUtilization(EsdbBwUtilPayload payload) {
+        String restPath = esdbProperties.getUri()+"bandwidth_utilization/";
+        log.info("create rest path: "+restPath);
+        EsdbBwUtil result = restTemplate.postForObject(restPath, payload, EsdbBwUtil.class);
+        if (result != null) {
+            log.info("created a ESDB bandwidth utilization: \n" + result.getEquipmentInterface()+ " : "+ result.getBandwidth());
+        }
+    }
+    public void deleteBandwidthUtilization(Integer bwutilPkId) {
+        String restPath = esdbProperties.getUri()+"bandwidth_utilization/"+bwutilPkId+"/";
+        log.info("delete rest path: "+restPath);
+        restTemplate.delete(restPath);
+    }
+
 }

--- a/backend/src/main/java/net/es/oscars/task/EsdbDataSync.java
+++ b/backend/src/main/java/net/es/oscars/task/EsdbDataSync.java
@@ -7,19 +7,31 @@ import net.es.oscars.app.Startup;
 import net.es.oscars.app.props.EsdbProperties;
 import net.es.oscars.app.props.StartupProperties;
 import net.es.oscars.esdb.ESDBProxy;
+import net.es.oscars.model.Interval;
+import net.es.oscars.resv.beans.PeriodBandwidth;
 import net.es.oscars.resv.db.ConnectionRepository;
 import net.es.oscars.resv.ent.Components;
 import net.es.oscars.resv.ent.Connection;
 import net.es.oscars.resv.ent.VlanFixture;
 import net.es.oscars.resv.enums.Phase;
+import net.es.oscars.resv.svc.ResvLibrary;
+import net.es.oscars.resv.svc.ResvService;
 import net.es.oscars.topo.beans.Port;
+import net.es.oscars.topo.beans.PortBwVlan;
+import net.es.oscars.topo.beans.TopoUrn;
+import net.es.oscars.topo.beans.Topology;
+import net.es.oscars.topo.pop.ConsistencyException;
 import net.es.oscars.topo.svc.TopologyStore;
+import net.es.topo.common.dto.esdb.EsdbBwUtil;
+import net.es.topo.common.dto.esdb.EsdbBwUtilPayload;
 import net.es.topo.common.dto.esdb.EsdbVlan;
 import net.es.topo.common.dto.esdb.EsdbVlanPayload;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 
@@ -27,7 +39,7 @@ import java.util.*;
 @Component
 @Getter
 @Setter
-public class EsdbVlanSync {
+public class EsdbDataSync {
     public static String PREFIX = "OSCARS";
     private final Startup startup;
     private final ConnectionRepository cr;
@@ -35,14 +47,19 @@ public class EsdbVlanSync {
     private final EsdbProperties esdbProperties;
     private final StartupProperties startupProperties;
     private final TopologyStore topologyStore;
+    private final ResvService resvService;
+
     private boolean isSynchronized = false;
-    public EsdbVlanSync(Startup startup, ConnectionRepository cr, ESDBProxy esdbProxy, EsdbProperties esdbProperties, StartupProperties startupProperties, TopologyStore topologyStore) {
+    public EsdbDataSync(Startup startup, ConnectionRepository cr, ESDBProxy esdbProxy,
+                        EsdbProperties esdbProperties, StartupProperties startupProperties,
+                        TopologyStore topologyStore, ResvService resvService) {
         this.startup = startup;
         this.cr = cr;
         this.esdbProxy = esdbProxy;
         this.esdbProperties = esdbProperties;
         this.startupProperties = startupProperties;
         this.topologyStore = topologyStore;
+        this.resvService = resvService;
     }
 
     @Scheduled(initialDelay = 120000, fixedDelayString ="${esdb.vlan-sync-period}" )
@@ -55,6 +72,32 @@ public class EsdbVlanSync {
         } else if (startup.isInStartup() || startup.isInShutdown()) {
             return;
         }
+        log.info("starting BW utilization sync");
+        List<EsdbBwUtil> currentUtilizations = esdbProxy.gqlBwUtil(null, null, null, null);
+        List<EsdbBwUtil>  bwUtilsToRemove = currentUtilizations.stream()
+                .filter(util -> util.getSystem().equals("oscars"))
+                .toList();
+        if (!bwUtilsToRemove.isEmpty()) {
+            log.info("deleting {}  OSCARS utilizations ", bwUtilsToRemove.size());
+            for (EsdbBwUtil util : bwUtilsToRemove) {
+                esdbProxy.deleteBandwidthUtilization(util.getId());
+            }
+        }
+
+
+        try {
+            topologyStore.getCurrentTopology();
+        } catch (ConsistencyException e) {
+            log.error("failed to get current topology for bandwidth sync", e);
+        }
+        List<EsdbBwUtilPayload> bwUtilsToAdd = this.makeBwPayloads();
+
+        for (EsdbBwUtilPayload bwUtilPayload : bwUtilsToAdd) {
+            esdbProxy.createBandwidthUtilization(bwUtilPayload);
+        }
+        log.info("created {} OSCARS bandwidth utilizations ", bwUtilsToAdd.size());
+
+
         log.info("starting VLAN sync");
         // fetch all ESDB vlans
         // ...Use GraphQL client.
@@ -165,4 +208,55 @@ public class EsdbVlanSync {
 
         return payloads;
     }
+
+    public List<EsdbBwUtilPayload> makeBwPayloads() {
+        List<EsdbBwUtilPayload> payloads = new ArrayList<>();
+        // a random UUID for this run
+        UUID uuid = UUID.randomUUID();
+
+        Interval thisWeek = Interval.builder()
+                .beginning(Instant.now())
+                .ending(Instant.now().plus(7, ChronoUnit.DAYS))
+                .build();
+        // first we collect any reservations overlapping the next week
+        // addy any ports that have a non-zero reservation to a set
+        Set<String> portsWithAnyReservations = new HashSet<>();
+        Map<String, List<PeriodBandwidth>> reservedIngBws = resvService.reservedIngBws(thisWeek, new HashMap<>(), null);
+        for (String portUrn : reservedIngBws.keySet()) {
+            for (PeriodBandwidth bw : reservedIngBws.get(portUrn)) {
+                if (bw.getBandwidth() > 0) {
+                    portsWithAnyReservations.add(portUrn);
+                }
+            }
+        }
+
+        Map<String, List<PeriodBandwidth>> reservedEgBws = resvService.reservedEgBws(thisWeek, new HashMap<>(), null);
+
+
+        Map<String, TopoUrn> topoUrnMap = topologyStore.getTopoUrnMap();
+        Map<String, PortBwVlan> available = ResvLibrary.portBwVlans(topoUrnMap, new ArrayList<>(), reservedIngBws, reservedEgBws);
+
+        for (String portUrn : portsWithAnyReservations) {
+            Optional<Port> p = topologyStore.findPortByUrn(portUrn);
+            if (p.isPresent()) {
+                Port port = p.get();
+                Integer availableBw = available.get(portUrn).getIngressBandwidth();
+                Integer baselineBw = port.getReservableIngressBw();
+                Integer reservedBw = baselineBw - availableBw;
+                EsdbBwUtilPayload payload = EsdbBwUtilPayload.builder()
+                        .bandwidth(reservedBw)
+                        .system("oscars")
+                        .bandwidth(reservedBw)
+                        .equipmentInterface(port.getEsdbEquipmentInterfaceId())
+                        .remoteSystemId(uuid.toString())
+                        .build();
+                payloads.add(payload);
+            } else {
+                log.error("portUrn: {} not found!", portUrn);
+            }
+        }
+
+        return payloads;
+    }
+
 }

--- a/backend/src/main/resources/graphql-documents/bandwidthUtilizationList.graphql
+++ b/backend/src/main/resources/graphql-documents/bandwidthUtilizationList.graphql
@@ -1,0 +1,20 @@
+query ($search: String, $sortProperty:String, $first:Int, $skip:Int) {
+    bandwidthUtilizationList(
+        search: $search,
+        sortProperty: $sortProperty
+        first: $first
+        skip: $skip
+    ) {
+        results: list {
+            id
+            uuid
+            bandwidth
+            remoteSystemId
+            system
+            equipmentInterface {
+                id
+            }
+        }
+        count: totalRecords
+    }
+}

--- a/backend/src/test/java/net/es/oscars/cuke/EsdbVlanSyncSteps.java
+++ b/backend/src/test/java/net/es/oscars/cuke/EsdbVlanSyncSteps.java
@@ -1,34 +1,18 @@
 package net.es.oscars.cuke;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.es.oscars.app.props.NsoProperties;
 import net.es.oscars.ctg.UnitTests;
 import net.es.oscars.esdb.ESDBProxy;
-import net.es.oscars.task.EsdbVlanSync;
+import net.es.oscars.task.EsdbDataSync;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.graphql.ResponseError;
-import org.springframework.graphql.client.ClientGraphQlResponse;
-import org.springframework.graphql.client.ClientResponseField;
-import org.springframework.graphql.client.GraphQlClient;
-import org.springframework.graphql.client.HttpSyncGraphQlClient;
-import org.springframework.util.StreamUtils;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.Charset;
-import java.util.List;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 
@@ -36,7 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 @Category({UnitTests.class})
 public class EsdbVlanSyncSteps extends CucumberSteps {
     @Autowired
-    private EsdbVlanSync esdbVlanSync;
+    private EsdbDataSync esdbDataSync;
 
     @Autowired
     private ESDBProxy esdbProxy;
@@ -50,29 +34,29 @@ public class EsdbVlanSyncSteps extends CucumberSteps {
     @Before("@EsdbVlanSyncSteps")
     public void before() throws IOException {
         log.info("EsdbVlanSyncSteps before() called.");
-        esdbVlanSync.setSynchronized(false);
-        esdbVlanSync.getStartup().setInStartup(false);
-        esdbVlanSync.getStartup().setInShutdown(false);
+        esdbDataSync.setSynchronized(false);
+        esdbDataSync.getStartup().setInStartup(false);
+        esdbDataSync.getStartup().setInShutdown(false);
 
         // Override with our mock server URL and port
-        esdbVlanSync.getEsdbProperties().setGraphqlUri("http://localhost:" + mockPort + "/esdb_api/graphql");
-        esdbVlanSync.getEsdbProperties().setUri("http://localhost:" + mockPort + "/esdb_api/v1");
+        esdbDataSync.getEsdbProperties().setGraphqlUri("http://localhost:" + mockPort + "/esdb_api/graphql");
+        esdbDataSync.getEsdbProperties().setUri("http://localhost:" + mockPort + "/esdb_api/v1");
     }
 
     @Given("The ESDB VLAN task is ready")
     public void esdbVlanTaskIsReady() {
-        assert esdbVlanSync != null;
-        assert !esdbVlanSync.isSynchronized();
+        assert esdbDataSync != null;
+        assert !esdbDataSync.isSynchronized();
     }
 
     @When("The ESDB VLAN synchronization is triggered")
     public void theESDBVLANSynchronizationIsTriggered() {
-        esdbVlanSync.processingLoop();
+        esdbDataSync.processingLoop();
     }
 
     @Then("The ESDB VLAN was synchronized")
     public void theESDBVLANWasSynchronized() {
-        assert esdbVlanSync.isSynchronized();
+        assert esdbDataSync.isSynchronized();
     }
 
 }

--- a/backend/src/test/resources/http/esdb.bwutil-list.json
+++ b/backend/src/test/resources/http/esdb.bwutil-list.json
@@ -1,0 +1,149 @@
+{
+  "data": {
+    "bandwidthUtilizationList": {
+      "results": [
+        {
+          "id": "191",
+          "uuid": "5e8a17da-a6c6-438e-ab71-24d0c42a31bf",
+          "bandwidth": 10000,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "13064"
+          }
+        },
+        {
+          "id": "192",
+          "uuid": "065d0fa0-9bb3-47fe-b3e8-807474661e8d",
+          "bandwidth": 10000,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "12128"
+          }
+        },
+        {
+          "id": "193",
+          "uuid": "0c32476d-ec41-4ed8-bbd1-9482ce76dd7b",
+          "bandwidth": 1000,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "16742"
+          }
+        },
+        {
+          "id": "194",
+          "uuid": "5afa1e24-6db5-4975-8671-b9cf2d6d5b54",
+          "bandwidth": 1900,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "16730"
+          }
+        },
+        {
+          "id": "195",
+          "uuid": "8a8669ce-5d46-4086-b974-db12a3855004",
+          "bandwidth": 10000,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "12805"
+          }
+        },
+        {
+          "id": "196",
+          "uuid": "7225ffe2-1010-411e-b69a-afc25a87a08d",
+          "bandwidth": 10000,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "13038"
+          }
+        },
+        {
+          "id": "197",
+          "uuid": "8032be0c-5e28-4d71-aa36-0c608ec10864",
+          "bandwidth": 1900,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "28893"
+          }
+        },
+        {
+          "id": "198",
+          "uuid": "69de235c-cc93-43b0-9e21-2eb38fc082c8",
+          "bandwidth": 10000,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "12797"
+          }
+        },
+        {
+          "id": "199",
+          "uuid": "85fd98df-44af-4795-bc8d-56bfb2149b9a",
+          "bandwidth": 10000,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "12098"
+          }
+        },
+        {
+          "id": "200",
+          "uuid": "ad02f583-5353-4440-88b3-dab956f936b5",
+          "bandwidth": 10000,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "12932"
+          }
+        },
+        {
+          "id": "201",
+          "uuid": "ce4cd760-b842-4d4e-9645-34161b2da423",
+          "bandwidth": 1000,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "28901"
+          }
+        },
+        {
+          "id": "202",
+          "uuid": "341e6cfb-b6a7-4d54-8dc5-96797cc31abe",
+          "bandwidth": 10000,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "12966"
+          }
+        },
+        {
+          "id": "203",
+          "uuid": "9d288fc8-d38e-4a08-ad59-c0830963e732",
+          "bandwidth": 10000,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "16413"
+          }
+        },
+        {
+          "id": "204",
+          "uuid": "ff38f626-a981-4576-8770-245f9f684489",
+          "bandwidth": 10000,
+          "remoteSystemId": "539dcc92-517f-45fc-88c8-311d1b7b9f06",
+          "system": "oscars",
+          "equipmentInterface": {
+            "id": "16402"
+          }
+        }
+      ],
+      "count": 14
+    }
+  }
+}

--- a/backend/src/test/resources/http/response-specs/esdb.graphql.response-specs.json
+++ b/backend/src/test/resources/http/response-specs/esdb.graphql.response-specs.json
@@ -16,6 +16,11 @@
     "status": 200,
     "match": "organizationList",
     "data": "http/esdb.org-list.json"
+  },
+  {
+    "method": "POST",
+    "status": 200,
+    "match": "bandwidthUtilizationList",
+    "data": "http/esdb.bwutil-list.json"
   }
-
 ]


### PR DESCRIPTION
### Description

Fetch all bandwidth utilizations with GQL, then delete any oscars ones and replace them with new ones

renames EsdbVlanSync to EsdbDataSync

### Checklist

- [x] PR Title format: `type: [OS-XXX] Short description` 
    - `type` is one of: 'build', 'ci', 'chore',  'docs',  'feat', 'fix',  'perf', 'refactor', 'revert', 'style', 'test' 
    - `OS-XXX` refers to a Jira issue. 
    - If this is a breaking change prefix the description with "BREAKING CHANGE:"
- [x] There is a related Jira issue for this pull request
- [x] Description should be a meaningful summary of the changes you are proposing
- [x] For breaking changes prefix the title with `"BREAKING CHANGE:"` and include details in the description
- [x] This PR includes tests related to these changes, or existing tests provide coverage
- [ ] This PR has updated documentation as appropriate
- [x] `mvn clean package` runs successfully

### Notes
- Once approved, use the **squash and merge** option.
- Refer to the [development notes](https://github.com/esnet/oscars/blob/master/docs/development_notes.md#pull-requests) for more details.
